### PR TITLE
增加 Shutdown 方法以支持优雅退出HTTP Server

### DIFF
--- a/route.go
+++ b/route.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,6 +20,7 @@ type Route struct {
 	route.Router
 	config   config.Config
 	instance *gin.Engine
+	server   *http.Server
 }
 
 func NewRoute(config config.Config, parameters map[string]any) (*Route, error) {
@@ -98,13 +100,13 @@ func (r *Route) Run(host ...string) error {
 	r.outputRoutes()
 	color.Green().Println(termlink.Link("[HTTP] Listening and serving HTTP on", "http://"+host[0]))
 
-	server := &http.Server{
+	r.server = &http.Server{
 		Addr:           host[0],
 		Handler:        http.AllowQuerySemicolons(r.instance),
 		MaxHeaderBytes: r.config.GetInt("http.drivers.gin.header_limit", 4096) << 10,
 	}
 
-	return server.ListenAndServe()
+	return r.server.ListenAndServe()
 }
 
 func (r *Route) RunTLS(host ...string) error {
@@ -135,11 +137,21 @@ func (r *Route) RunTLSWithCert(host, certFile, keyFile string) error {
 	r.outputRoutes()
 	color.Green().Println(termlink.Link("[HTTPS] Listening and serving HTTPS on", "https://"+host))
 
-	return r.instance.RunTLS(host, certFile, keyFile)
+	r.server = &http.Server{
+		Addr:           host,
+		Handler:        http.AllowQuerySemicolons(r.instance),
+		MaxHeaderBytes: r.config.GetInt("http.drivers.gin.header_limit", 4096) << 10,
+	}
+
+	return r.server.ListenAndServeTLS(certFile, keyFile)
 }
 
 func (r *Route) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	r.instance.ServeHTTP(writer, request)
+}
+
+func (r *Route) Shutdown(ctx context.Context) error {
+	return r.server.Shutdown(ctx)
 }
 
 func (r *Route) outputRoutes() {

--- a/route_test.go
+++ b/route_test.go
@@ -1,12 +1,15 @@
 package gin
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -381,6 +384,115 @@ func TestNewRoute(t *testing.T) {
 
 			mockConfig.AssertExpectations(t)
 		})
+	}
+}
+
+func TestShutdown(t *testing.T) {
+	var (
+		err        error
+		mockConfig *configmocks.Config
+		route      *Route
+		count      atomic.Int64
+	)
+
+	tests := []struct {
+		name  string
+		setup func(host string, port string) error
+		host  string
+		port  string
+	}{
+		{
+			name: "no new requests will be accepted after shutdown",
+			setup: func(host string, port string) error {
+				mockConfig.On("GetBool", "app.debug").Return(true).Once()
+				mockConfig.On("GetString", "http.host").Return(host).Once()
+				mockConfig.On("GetString", "http.port").Return(port).Once()
+				mockConfig.On("GetInt", "http.drivers.gin.header_limit", 4096).Return(4096).Once()
+
+				go func() {
+					assert.EqualError(t, route.Run(), http.ErrServerClosed.Error())
+				}()
+
+				time.Sleep(1 * time.Second)
+
+				addr := "http://" + host + ":" + port
+				assertHttpNormal(t, addr, true)
+
+				assert.Nil(t, route.Shutdown(context.Background()))
+
+				assertHttpNormal(t, addr, false)
+				return nil
+			},
+			host: "127.0.0.1",
+			port: "3031",
+		},
+		{
+			name: "Ensure that received requests are processed",
+			setup: func(host string, port string) error {
+				mockConfig.On("GetBool", "app.debug").Return(true).Once()
+				mockConfig.On("GetString", "http.host").Return(host).Once()
+				mockConfig.On("GetString", "http.port").Return(port).Once()
+				mockConfig.On("GetInt", "http.drivers.gin.header_limit", 4096).Return(4096).Once()
+
+				go func() {
+					assert.EqualError(t, route.Run(), http.ErrServerClosed.Error())
+				}()
+
+				time.Sleep(1 * time.Second)
+
+				addr := "http://" + host + ":" + port
+				wg := sync.WaitGroup{}
+
+				for i := 0; i < 3; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						assertHttpNormal(t, addr, true)
+					}()
+				}
+				time.Sleep(100 * time.Millisecond)
+				assert.Nil(t, route.Shutdown(context.Background()))
+				assertHttpNormal(t, addr, false)
+				wg.Wait()
+				assert.Equal(t, count.Load(), int64(3))
+				return nil
+			},
+			host: "127.0.0.1",
+			port: "3031",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockConfig = &configmocks.Config{}
+			mockConfig.On("GetBool", "app.debug").Return(true).Once()
+			mockConfig.On("GetInt", "http.drivers.gin.body_limit", 4096).Return(4096).Once()
+
+			route, err = NewRoute(mockConfig, nil)
+			assert.Nil(t, err)
+			route.Get("/", func(ctx contractshttp.Context) contractshttp.Response {
+				time.Sleep(time.Second)
+				defer count.Add(1)
+				return ctx.Response().Json(200, contractshttp.Json{
+					"Hello": "Goravel",
+				})
+			})
+			if err := test.setup(test.host, test.port); err == nil {
+				assert.Nil(t, err)
+			}
+			mockConfig.AssertExpectations(t)
+		})
+	}
+}
+
+func assertHttpNormal(t *testing.T, addr string, expectNormal bool) {
+	resp, err := http.DefaultClient.Get(addr)
+	if !expectNormal {
+		assert.NotNil(t, err)
+		assert.Nil(t, resp)
+	} else {
+		assert.Nil(t, err)
+		assert.NotNil(t, resp)
 	}
 }
 


### PR DESCRIPTION
….AllowQuerySemicolons和MaxHeaderBytes配置

1. 统一 Run/RunTLS/RunTLSWithCert 行为，原先的写法RunTLS/RunTLSWithCert没有应用http.AllowQuerySemicolons和MaxHeaderBytes配置
2. 增加 Shutdown 方法以支持优雅退出HTTP Server

## 📑 Description

Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
