### PR TITLE
feat: add Shutdown to support graceful quit of HTTP Server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gookit/validate v1.5.2
-	github.com/goravel/framework v1.14.3
+	github.com/goravel/framework v1.14.5-0.20240904064435-05476fa00c9c
 	github.com/rs/cors v1.11.0
 	github.com/savioxavier/termlink v1.3.0
 	github.com/spf13/cast v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,8 @@ github.com/goravel/file-rotatelogs/v2 v2.4.2 h1:g68AzbePXcm0V2CpUMc9j4qVzcDn7+7a
 github.com/goravel/file-rotatelogs/v2 v2.4.2/go.mod h1:23VuSW8cBS4ax5cmbV+5AaiLpq25b8UJ96IhbAkdo8I=
 github.com/goravel/framework v1.14.3 h1:H2sKrmsxCvVGRBbeewjXXLWsCAvk1o5kVskNymDfpfw=
 github.com/goravel/framework v1.14.3/go.mod h1:rScDXGQZdoVfyxemNPmijlz/2a+lWNOa4jTuak5GGVg=
+github.com/goravel/framework v1.14.5-0.20240904064435-05476fa00c9c h1:RiMpkbasXxmNmE/pLCy6lqmu3uOadyhICiqMtgroA7I=
+github.com/goravel/framework v1.14.5-0.20240904064435-05476fa00c9c/go.mod h1:rScDXGQZdoVfyxemNPmijlz/2a+lWNOa4jTuak5GGVg=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/route.go
+++ b/route.go
@@ -156,7 +156,7 @@ func (r *Route) Shutdown(ctx context.Context) error {
 		return r.server.Shutdown(ctx)
 	}
 	if r.tlsServer != nil {
-		return r.server.Shutdown(ctx)
+		return r.tlsServer.Shutdown(ctx)
 	}
 	return nil
 }

--- a/route.go
+++ b/route.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -19,6 +20,7 @@ type Route struct {
 	route.Router
 	config   config.Config
 	instance *gin.Engine
+	server   *http.Server
 }
 
 func NewRoute(config config.Config, parameters map[string]any) (*Route, error) {
@@ -98,13 +100,13 @@ func (r *Route) Run(host ...string) error {
 	r.outputRoutes()
 	color.Green().Println(termlink.Link("[HTTP] Listening and serving HTTP on", "http://"+host[0]))
 
-	server := &http.Server{
+	r.server = &http.Server{
 		Addr:           host[0],
 		Handler:        http.AllowQuerySemicolons(r.instance),
 		MaxHeaderBytes: r.config.GetInt("http.drivers.gin.header_limit", 4096) << 10,
 	}
 
-	return server.ListenAndServe()
+	return r.server.ListenAndServe()
 }
 
 func (r *Route) RunTLS(host ...string) error {
@@ -135,11 +137,21 @@ func (r *Route) RunTLSWithCert(host, certFile, keyFile string) error {
 	r.outputRoutes()
 	color.Green().Println(termlink.Link("[HTTPS] Listening and serving HTTPS on", "https://"+host))
 
-	return r.instance.RunTLS(host, certFile, keyFile)
+	r.server = &http.Server{
+		Addr:           host,
+		Handler:        http.AllowQuerySemicolons(r.instance),
+		MaxHeaderBytes: r.config.GetInt("http.drivers.gin.header_limit", 4096) << 10,
+	}
+
+	return r.server.ListenAndServeTLS(certFile, keyFile)
 }
 
 func (r *Route) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
 	r.instance.ServeHTTP(writer, request)
+}
+
+func (r *Route) Shutdown(ctx context.Context) error {
+	return r.server.Shutdown(ctx)
 }
 
 func (r *Route) outputRoutes() {

--- a/route_test.go
+++ b/route_test.go
@@ -1,12 +1,15 @@
 package gin
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"io"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -381,6 +384,115 @@ func TestNewRoute(t *testing.T) {
 
 			mockConfig.AssertExpectations(t)
 		})
+	}
+}
+
+func TestShutdown(t *testing.T) {
+	var (
+		err        error
+		mockConfig *configmocks.Config
+		route      *Route
+		count      atomic.Int64
+	)
+
+	tests := []struct {
+		name  string
+		setup func(host string, port string) error
+		host  string
+		port  string
+	}{
+		{
+			name: "no new requests will be accepted after shutdown",
+			setup: func(host string, port string) error {
+				mockConfig.On("GetBool", "app.debug").Return(true).Once()
+				mockConfig.On("GetString", "http.host").Return(host).Once()
+				mockConfig.On("GetString", "http.port").Return(port).Once()
+				mockConfig.On("GetInt", "http.drivers.gin.header_limit", 4096).Return(4096).Once()
+
+				go func() {
+					assert.EqualError(t, route.Run(), http.ErrServerClosed.Error())
+				}()
+
+				time.Sleep(1 * time.Second)
+
+				addr := "http://" + host + ":" + port
+				assertHttpNormal(t, addr, true)
+
+				assert.Nil(t, route.Shutdown(context.Background()))
+
+				assertHttpNormal(t, addr, false)
+				return nil
+			},
+			host: "127.0.0.1",
+			port: "3031",
+		},
+		{
+			name: "Ensure that received requests are processed",
+			setup: func(host string, port string) error {
+				mockConfig.On("GetBool", "app.debug").Return(true).Once()
+				mockConfig.On("GetString", "http.host").Return(host).Once()
+				mockConfig.On("GetString", "http.port").Return(port).Once()
+				mockConfig.On("GetInt", "http.drivers.gin.header_limit", 4096).Return(4096).Once()
+
+				go func() {
+					assert.EqualError(t, route.Run(), http.ErrServerClosed.Error())
+				}()
+
+				time.Sleep(1 * time.Second)
+
+				addr := "http://" + host + ":" + port
+				wg := sync.WaitGroup{}
+				count.Store(0)
+				for i := 0; i < 3; i++ {
+					wg.Add(1)
+					go func() {
+						defer wg.Done()
+						assertHttpNormal(t, addr, true)
+					}()
+				}
+				time.Sleep(100 * time.Millisecond)
+				assert.Nil(t, route.Shutdown(context.Background()))
+				assertHttpNormal(t, addr, false)
+				wg.Wait()
+				assert.Equal(t, count.Load(), int64(3))
+				return nil
+			},
+			host: "127.0.0.1",
+			port: "3031",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockConfig = &configmocks.Config{}
+			mockConfig.On("GetBool", "app.debug").Return(true).Once()
+			mockConfig.On("GetInt", "http.drivers.gin.body_limit", 4096).Return(4096).Once()
+
+			route, err = NewRoute(mockConfig, nil)
+			assert.Nil(t, err)
+			route.Get("/", func(ctx contractshttp.Context) contractshttp.Response {
+				time.Sleep(time.Second)
+				defer count.Add(1)
+				return ctx.Response().Json(200, contractshttp.Json{
+					"Hello": "Goravel",
+				})
+			})
+			if err := test.setup(test.host, test.port); err == nil {
+				assert.Nil(t, err)
+			}
+			mockConfig.AssertExpectations(t)
+		})
+	}
+}
+
+func assertHttpNormal(t *testing.T, addr string, expectNormal bool) {
+	resp, err := http.DefaultClient.Get(addr)
+	if !expectNormal {
+		assert.NotNil(t, err)
+		assert.Nil(t, resp)
+	} else {
+		assert.Nil(t, err)
+		assert.NotNil(t, resp)
 	}
 }
 

--- a/route_test.go
+++ b/route_test.go
@@ -23,8 +23,8 @@ import (
 
 func TestFallback(t *testing.T) {
 	mockConfig := &configmocks.Config{}
-	mockConfig.On("GetBool", "app.debug").Return(true).Once()
-	mockConfig.On("GetInt", "http.drivers.gin.body_limit", 4096).Return(4096).Once()
+	mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+	mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
 
 	w := httptest.NewRecorder()
 	req, _ := http.NewRequest("GET", "/fallback", nil)
@@ -61,8 +61,8 @@ func TestRun(t *testing.T) {
 		{
 			name: "error when default port is empty",
 			setup: func(host string, port string) error {
-				mockConfig.On("GetString", "http.host").Return(host).Once()
-				mockConfig.On("GetString", "http.port").Return(port).Once()
+				mockConfig.EXPECT().GetString("http.host").Return(host).Once()
+				mockConfig.EXPECT().GetString("http.port").Return(port).Once()
 
 				go func() {
 					assert.EqualError(t, route.Run(), "port can't be empty")
@@ -76,10 +76,10 @@ func TestRun(t *testing.T) {
 		{
 			name: "use default host",
 			setup: func(host string, port string) error {
-				mockConfig.On("GetBool", "app.debug").Return(true).Once()
-				mockConfig.On("GetString", "http.host").Return(host).Once()
-				mockConfig.On("GetString", "http.port").Return(port).Once()
-				mockConfig.On("GetInt", "http.drivers.gin.header_limit", 4096).Return(4096).Once()
+				mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+				mockConfig.EXPECT().GetString("http.host").Return(host).Once()
+				mockConfig.EXPECT().GetString("http.port").Return(port).Once()
+				mockConfig.EXPECT().GetInt("http.drivers.gin.header_limit", 4096).Return(4096).Once()
 
 				go func() {
 					assert.Nil(t, route.Run())
@@ -95,8 +95,8 @@ func TestRun(t *testing.T) {
 		{
 			name: "use custom host",
 			setup: func(host string, port string) error {
-				mockConfig.On("GetBool", "app.debug").Return(true).Once()
-				mockConfig.On("GetInt", "http.drivers.gin.header_limit", 4096).Return(4096).Once()
+				mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+				mockConfig.EXPECT().GetInt("http.drivers.gin.header_limit", 4096).Return(4096).Once()
 
 				go func() {
 					assert.Nil(t, route.Run(host))
@@ -111,8 +111,8 @@ func TestRun(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockConfig = &configmocks.Config{}
-			mockConfig.On("GetBool", "app.debug").Return(true).Once()
-			mockConfig.On("GetInt", "http.drivers.gin.body_limit", 4096).Return(4096).Once()
+			mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+			mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
 
 			route, err = NewRoute(mockConfig, nil)
 			assert.Nil(t, err)
@@ -157,8 +157,8 @@ func TestRunTLS(t *testing.T) {
 		{
 			name: "error when default port is empty",
 			setup: func(host string, port string) error {
-				mockConfig.On("GetString", "http.tls.host").Return(host).Once()
-				mockConfig.On("GetString", "http.tls.port").Return(port).Once()
+				mockConfig.EXPECT().GetString("http.tls.host").Return(host).Once()
+				mockConfig.EXPECT().GetString("http.tls.port").Return(port).Once()
 
 				go func() {
 					assert.EqualError(t, route.RunTLS(), "port can't be empty")
@@ -172,11 +172,12 @@ func TestRunTLS(t *testing.T) {
 		{
 			name: "use default host",
 			setup: func(host string, port string) error {
-				mockConfig.On("GetBool", "app.debug").Return(true).Once()
-				mockConfig.On("GetString", "http.tls.host").Return(host).Once()
-				mockConfig.On("GetString", "http.tls.port").Return(port).Once()
-				mockConfig.On("GetString", "http.tls.ssl.cert").Return("test_ca.crt").Once()
-				mockConfig.On("GetString", "http.tls.ssl.key").Return("test_ca.key").Once()
+				mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+				mockConfig.EXPECT().GetInt("http.drivers.gin.header_limit", 4096).Return(4096).Once()
+				mockConfig.EXPECT().GetString("http.tls.host").Return(host).Once()
+				mockConfig.EXPECT().GetString("http.tls.port").Return(port).Once()
+				mockConfig.EXPECT().GetString("http.tls.ssl.cert").Return("test_ca.crt").Once()
+				mockConfig.EXPECT().GetString("http.tls.ssl.key").Return("test_ca.key").Once()
 
 				go func() {
 					assert.Nil(t, route.RunTLS())
@@ -190,9 +191,10 @@ func TestRunTLS(t *testing.T) {
 		{
 			name: "use custom host",
 			setup: func(host string, port string) error {
-				mockConfig.On("GetBool", "app.debug").Return(true).Once()
-				mockConfig.On("GetString", "http.tls.ssl.cert").Return("test_ca.crt").Once()
-				mockConfig.On("GetString", "http.tls.ssl.key").Return("test_ca.key").Once()
+				mockConfig.EXPECT().GetInt("http.drivers.gin.header_limit", 4096).Return(4096).Once()
+				mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+				mockConfig.EXPECT().GetString("http.tls.ssl.cert").Return("test_ca.crt").Once()
+				mockConfig.EXPECT().GetString("http.tls.ssl.key").Return("test_ca.key").Once()
 
 				go func() {
 					assert.Nil(t, route.RunTLS(host))
@@ -206,9 +208,9 @@ func TestRunTLS(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mockConfig = &configmocks.Config{}
-			mockConfig.On("GetBool", "app.debug").Return(true).Once()
-			mockConfig.On("GetInt", "http.drivers.gin.body_limit", 4096).Return(4096).Once()
+			mockConfig = configmocks.NewConfig(t)
+			mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+			mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
 
 			route, err = NewRoute(mockConfig, nil)
 			assert.Nil(t, err)
@@ -235,7 +237,6 @@ func TestRunTLS(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, "{\"Hello\":\"Goravel\"}", string(body))
 			}
-			mockConfig.AssertExpectations(t)
 		})
 	}
 }
@@ -267,7 +268,8 @@ func TestRunTLSWithCert(t *testing.T) {
 		{
 			name: "use default host",
 			setup: func(host string) error {
-				mockConfig.On("GetBool", "app.debug").Return(true).Once()
+				mockConfig.EXPECT().GetInt("http.drivers.gin.header_limit", 4096).Return(4096).Once()
+				mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
 
 				go func() {
 					assert.Nil(t, route.RunTLSWithCert(host, "test_ca.crt", "test_ca.key"))
@@ -280,7 +282,8 @@ func TestRunTLSWithCert(t *testing.T) {
 		{
 			name: "use custom host",
 			setup: func(host string) error {
-				mockConfig.On("GetBool", "app.debug").Return(true).Once()
+				mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+				mockConfig.EXPECT().GetInt("http.drivers.gin.header_limit", 4096).Return(4096).Once()
 
 				go func() {
 					assert.Nil(t, route.RunTLSWithCert(host, "test_ca.crt", "test_ca.key"))
@@ -294,9 +297,9 @@ func TestRunTLSWithCert(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mockConfig = &configmocks.Config{}
-			mockConfig.On("GetBool", "app.debug").Return(true).Once()
-			mockConfig.On("GetInt", "http.drivers.gin.body_limit", 4096).Return(4096).Once()
+			mockConfig = configmocks.NewConfig(t)
+			mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+			mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
 
 			route, err = NewRoute(mockConfig, nil)
 			assert.Nil(t, err)
@@ -319,7 +322,6 @@ func TestRunTLSWithCert(t *testing.T) {
 				assert.Nil(t, err)
 				assert.Equal(t, "{\"Hello\":\"Goravel\"}", string(body))
 			}
-			mockConfig.AssertExpectations(t)
 		})
 	}
 }
@@ -345,7 +347,7 @@ func TestNewRoute(t *testing.T) {
 			name:       "template is instance",
 			parameters: map[string]any{"driver": "gin"},
 			setup: func() {
-				mockConfig.On("Get", "http.drivers.gin.template").Return(defaultTemplate).Once()
+				mockConfig.EXPECT().Get("http.drivers.gin.template").Return(defaultTemplate).Once()
 			},
 			expectHTMLRender: defaultTemplate,
 		},
@@ -353,7 +355,7 @@ func TestNewRoute(t *testing.T) {
 			name:       "template is callback and returns success",
 			parameters: map[string]any{"driver": "gin"},
 			setup: func() {
-				mockConfig.On("Get", "http.drivers.gin.template").Return(func() (render.HTMLRender, error) {
+				mockConfig.EXPECT().Get("http.drivers.gin.template").Return(func() (render.HTMLRender, error) {
 					return defaultTemplate, nil
 				}).Twice()
 			},
@@ -363,7 +365,7 @@ func TestNewRoute(t *testing.T) {
 			name:       "template is callback and returns error",
 			parameters: map[string]any{"driver": "gin"},
 			setup: func() {
-				mockConfig.On("Get", "http.drivers.gin.template").Return(func() (render.HTMLRender, error) {
+				mockConfig.EXPECT().Get("http.drivers.gin.template").Return(func() (render.HTMLRender, error) {
 					return nil, errors.New("error")
 				}).Twice()
 			},
@@ -374,8 +376,8 @@ func TestNewRoute(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockConfig = configmocks.NewConfig(t)
-			mockConfig.On("GetBool", "app.debug").Return(true).Once()
-			mockConfig.On("GetInt", "http.drivers.gin.body_limit", 4096).Return(4096).Once()
+			mockConfig.EXPECT().GetBool("app.debug").Return(true).Once()
+			mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
 			test.setup()
 			route, err := NewRoute(mockConfig, test.parameters)
 			assert.Equal(t, test.expectError, err)
@@ -450,7 +452,7 @@ func TestShutdown(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			mockConfig = &configmocks.Config{}
+			mockConfig = configmocks.NewConfig(t)
 			mockConfig.EXPECT().GetBool("app.debug").Return(true)
 			mockConfig.EXPECT().GetInt("http.drivers.gin.header_limit", 4096).Return(4096).Once()
 			mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
@@ -466,7 +468,6 @@ func TestShutdown(t *testing.T) {
 			if err := test.setup(); err == nil {
 				assert.Nil(t, err)
 			}
-			mockConfig.AssertExpectations(t)
 		})
 	}
 }


### PR DESCRIPTION
fix: Unify the behavior of Run/RunTLS/RunTLSWithCert. The original RunTLS/RunTLSWithCert did not apply the http.AllowQuerySemicolons and MaxHeaderBytes configuration.

## 📑 Description

Closes https://github.com/goravel/goravel/issues/?

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
