### PR TITLE
refactor: change `WithValue` key type to any

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,7 +2,6 @@ package gin
 
 import (
 	"context"
-	"fmt"
 	"net/http/httptest"
 	"time"
 
@@ -46,17 +45,16 @@ func (c *Context) Response() http.ContextResponse {
 }
 
 func (c *Context) WithValue(key any, value any) {
-	c.instance.Set(fmt.Sprintf("%v", key), value) // need to store the key-val to the underlying gin too
-	//nolint:all
-	c.ctx = context.WithValue(c.ctx, key, value)
+	goravelCtx := c.getGoravelCtx()
+	goravelCtx[key] = value
+	c.instance.Set(goravelContextKey, goravelCtx)
 }
 
 func (c *Context) Context() context.Context {
-	for key, value := range c.instance.Keys {
-		// nolint
+	for key, value := range c.getGoravelCtx() {
+		//nolint:all
 		c.ctx = context.WithValue(c.ctx, key, value)
 	}
-
 	return c.ctx
 }
 

--- a/context.go
+++ b/context.go
@@ -11,6 +11,8 @@ import (
 	"github.com/goravel/framework/contracts/http"
 )
 
+const goravelContextKey = "goravel_contextKey"
+
 func Background() http.Context {
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	return NewContext(ctx)
@@ -56,6 +58,15 @@ func (c *Context) Context() context.Context {
 	}
 
 	return c.ctx
+}
+
+func (c *Context) getGoravelCtx() map[any]any {
+	if val, exist := c.instance.Get(goravelContextKey); exist {
+		if goravelCtxVal, ok := val.(map[any]any); ok {
+			return goravelCtxVal
+		}
+	}
+	return make(map[any]any)
 }
 
 func (c *Context) Deadline() (deadline time.Time, ok bool) {

--- a/context.go
+++ b/context.go
@@ -2,6 +2,7 @@ package gin
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"time"
 
@@ -45,6 +46,7 @@ func (c *Context) Response() http.ContextResponse {
 }
 
 func (c *Context) WithValue(key any, value any) {
+	c.instance.Set(fmt.Sprintf("%v", key), value) // need to store the key-val to the underlying gin too
 	//nolint:all
 	c.Ctx = context.WithValue(c.Ctx, key, value)
 }
@@ -71,7 +73,7 @@ func (c *Context) Err() error {
 }
 
 func (c *Context) Value(key any) any {
-	return c.Ctx.Value(key)
+	return c.Context().Value(key)
 }
 
 func (c *Context) Instance() *gin.Context {

--- a/context.go
+++ b/context.go
@@ -18,13 +18,12 @@ func Background() http.Context {
 }
 
 type Context struct {
-	ctx      context.Context
 	instance *gin.Context
 	request  http.ContextRequest
 }
 
 func NewContext(ctx *gin.Context) http.Context {
-	return &Context{instance: ctx, ctx: context.Background()}
+	return &Context{instance: ctx}
 }
 
 func (c *Context) Request() http.ContextRequest {
@@ -50,13 +49,7 @@ func (c *Context) WithValue(key any, value any) {
 	c.instance.Set(goravelContextKey, goravelCtx)
 }
 
-func (c *Context) Context() context.Context {
-	for key, value := range c.getGoravelCtx() {
-		//nolint:all
-		c.ctx = context.WithValue(c.ctx, key, value)
-	}
-	return c.ctx
-}
+func (c *Context) Context() context.Context { return c }
 
 func (c *Context) getGoravelCtx() map[any]any {
 	if val, exist := c.instance.Get(goravelContextKey); exist {
@@ -80,7 +73,7 @@ func (c *Context) Err() error {
 }
 
 func (c *Context) Value(key any) any {
-	return c.Context().Value(key)
+	return c.getGoravelCtx()[key]
 }
 
 func (c *Context) Instance() *gin.Context {

--- a/context.go
+++ b/context.go
@@ -16,16 +16,14 @@ func Background() http.Context {
 	return NewContext(ctx)
 }
 
-type Ctx context.Context
-
 type Context struct {
-	Ctx
+	ctx      context.Context
 	instance *gin.Context
 	request  http.ContextRequest
 }
 
 func NewContext(ctx *gin.Context) http.Context {
-	return &Context{instance: ctx, Ctx: context.Background()}
+	return &Context{instance: ctx, ctx: context.Background()}
 }
 
 func (c *Context) Request() http.ContextRequest {
@@ -48,16 +46,16 @@ func (c *Context) Response() http.ContextResponse {
 func (c *Context) WithValue(key any, value any) {
 	c.instance.Set(fmt.Sprintf("%v", key), value) // need to store the key-val to the underlying gin too
 	//nolint:all
-	c.Ctx = context.WithValue(c.Ctx, key, value)
+	c.ctx = context.WithValue(c.ctx, key, value)
 }
 
 func (c *Context) Context() context.Context {
 	for key, value := range c.instance.Keys {
 		// nolint
-		c.Ctx = context.WithValue(c.Ctx, key, value)
+		c.ctx = context.WithValue(c.ctx, key, value)
 	}
 
-	return c.Ctx
+	return c.ctx
 }
 
 func (c *Context) Deadline() (deadline time.Time, ok bool) {

--- a/context_test.go
+++ b/context_test.go
@@ -7,10 +7,26 @@ import (
 )
 
 func TestContext(t *testing.T) {
+	// even with the same underlying empty struct, Go will still distinguish between
+	//  each type declaration
+	type customType struct{}
+	type anotherCustomType struct{}
+	var customTypeKey customType
+	var anotherCustomTypeKey anotherCustomType
+
 	httpCtx := Background()
 	httpCtx.WithValue("Hello", "world")
 	httpCtx.WithValue("Hi", "Goravel")
+	httpCtx.WithValue(customTypeKey, "halo")
+	httpCtx.WithValue(anotherCustomTypeKey, "hola")
+	httpCtx.WithValue(1, "one")
+	httpCtx.WithValue(2.2, "two point two")
+
 	ctx := httpCtx.Context()
 	assert.Equal(t, ctx.Value("Hello").(string), "world")
 	assert.Equal(t, ctx.Value("Hi").(string), "Goravel")
+	assert.Equal(t, "halo", ctx.Value(customTypeKey))
+	assert.Equal(t, "hola", ctx.Value(anotherCustomTypeKey))
+	assert.Equal(t, "one", ctx.Value(1))
+	assert.Equal(t, "two point two", ctx.Value(2.2))
 }

--- a/context_test.go
+++ b/context_test.go
@@ -23,8 +23,8 @@ func TestContext(t *testing.T) {
 	httpCtx.WithValue(2.2, "two point two")
 
 	ctx := httpCtx.Context()
-	assert.Equal(t, ctx.Value("Hello").(string), "world")
-	assert.Equal(t, ctx.Value("Hi").(string), "Goravel")
+	assert.Equal(t, "world", ctx.Value("Hello"))
+	assert.Equal(t, "Goravel", ctx.Value("Hi"))
 	assert.Equal(t, "halo", ctx.Value(customTypeKey))
 	assert.Equal(t, "hola", ctx.Value(anotherCustomTypeKey))
 	assert.Equal(t, "one", ctx.Value(1))

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gookit/validate v1.5.2
-	github.com/goravel/framework v1.14.5
+	github.com/goravel/framework v1.14.6-0.20240912145232-6543aeadf1bc
 	github.com/rs/cors v1.11.0
 	github.com/savioxavier/termlink v1.3.0
 	github.com/spf13/cast v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,8 @@ github.com/goravel/file-rotatelogs/v2 v2.4.2 h1:g68AzbePXcm0V2CpUMc9j4qVzcDn7+7a
 github.com/goravel/file-rotatelogs/v2 v2.4.2/go.mod h1:23VuSW8cBS4ax5cmbV+5AaiLpq25b8UJ96IhbAkdo8I=
 github.com/goravel/framework v1.14.5 h1:FItqxRGkBK0h/TIknF24TuMZCtBRaSr3DnQLEzhfvXc=
 github.com/goravel/framework v1.14.5/go.mod h1:rScDXGQZdoVfyxemNPmijlz/2a+lWNOa4jTuak5GGVg=
+github.com/goravel/framework v1.14.6-0.20240912145232-6543aeadf1bc h1:mWObAigy7PhrJkq1uK2KvV34JkTb8gIRxD8RU66MQVU=
+github.com/goravel/framework v1.14.6-0.20240912145232-6543aeadf1bc/go.mod h1:rScDXGQZdoVfyxemNPmijlz/2a+lWNOa4jTuak5GGVg=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDaL56wXCB/5+wF6uHfaI=

--- a/group_test.go
+++ b/group_test.go
@@ -435,16 +435,16 @@ func TestGroup(t *testing.T) {
 						route2.Get("/middleware/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 							return ctx.Response().Success().Json(contractshttp.Json{
 								"id":   ctx.Request().Input("id"),
-								"ctx":  ctx.Value("ctx").(string),
-								"ctx1": ctx.Value("ctx1").(string),
+								"ctx":  ctx.Value("ctx"),
+								"ctx1": ctx.Value("ctx1"),
 							})
 						})
 					})
 					route1.Middleware(contextMiddleware2()).Get("/middleware/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 						return ctx.Response().Success().Json(contractshttp.Json{
 							"id":   ctx.Request().Input("id"),
-							"ctx":  ctx.Value("ctx").(string),
-							"ctx2": ctx.Value("ctx2").(string),
+							"ctx":  ctx.Value("ctx"),
+							"ctx2": ctx.Value("ctx2"),
 						})
 					})
 				})
@@ -462,16 +462,16 @@ func TestGroup(t *testing.T) {
 						route2.Get("/middleware/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 							return ctx.Response().Success().Json(contractshttp.Json{
 								"id":   ctx.Request().Input("id"),
-								"ctx":  ctx.Value("ctx").(string),
-								"ctx1": ctx.Value("ctx1").(string),
+								"ctx":  ctx.Value("ctx"),
+								"ctx1": ctx.Value("ctx1"),
 							})
 						})
 					})
 					route1.Middleware(contextMiddleware2()).Get("/middleware/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 						return ctx.Response().Success().Json(contractshttp.Json{
 							"id":   ctx.Request().Input("id"),
-							"ctx":  ctx.Value("ctx").(string),
-							"ctx2": ctx.Value("ctx2").(string),
+							"ctx":  ctx.Value("ctx"),
+							"ctx2": ctx.Value("ctx2"),
 						})
 					})
 				})

--- a/group_test.go
+++ b/group_test.go
@@ -242,6 +242,10 @@ func TestGroup(t *testing.T) {
 
 				resource := resourceController{}
 				gin.GlobalMiddleware(func(ctx contractshttp.Context) {
+					type customKey struct{}
+					var customKeyCtx customKey
+					ctx.WithValue(customKeyCtx, "context with custom key")
+					ctx.WithValue(2.2, "two point two")
 					ctx.WithValue("action", "index")
 					ctx.Request().Next()
 				})
@@ -263,6 +267,10 @@ func TestGroup(t *testing.T) {
 
 				resource := resourceController{}
 				gin.GlobalMiddleware(func(ctx contractshttp.Context) {
+					type customKey struct{}
+					var customKeyCtx customKey
+					ctx.WithValue(customKeyCtx, "context with custom key")
+					ctx.WithValue(2.2, "two point two")
 					ctx.WithValue("action", "show")
 					ctx.Request().Next()
 				})
@@ -284,6 +292,10 @@ func TestGroup(t *testing.T) {
 
 				resource := resourceController{}
 				gin.GlobalMiddleware(func(ctx contractshttp.Context) {
+					type customKey struct{}
+					var customKeyCtx customKey
+					ctx.WithValue(customKeyCtx, "context with custom key")
+					ctx.WithValue(2.2, "two point two")
 					ctx.WithValue("action", "store")
 					ctx.Request().Next()
 				})
@@ -305,6 +317,10 @@ func TestGroup(t *testing.T) {
 
 				resource := resourceController{}
 				gin.GlobalMiddleware(func(ctx contractshttp.Context) {
+					type customKey struct{}
+					var customKeyCtx customKey
+					ctx.WithValue(customKeyCtx, "context with custom key")
+					ctx.WithValue(2.2, "two point two")
 					ctx.WithValue("action", "update")
 					ctx.Request().Next()
 				})
@@ -326,6 +342,10 @@ func TestGroup(t *testing.T) {
 
 				resource := resourceController{}
 				gin.GlobalMiddleware(func(ctx contractshttp.Context) {
+					type customKey struct{}
+					var customKeyCtx customKey
+					ctx.WithValue(customKeyCtx, "context with custom key")
+					ctx.WithValue(2.2, "two point two")
 					ctx.WithValue("action", "update")
 					ctx.Request().Next()
 				})
@@ -347,6 +367,10 @@ func TestGroup(t *testing.T) {
 
 				resource := resourceController{}
 				gin.GlobalMiddleware(func(ctx contractshttp.Context) {
+					type customKey struct{}
+					var customKeyCtx customKey
+					ctx.WithValue(customKeyCtx, "context with custom key")
+					ctx.WithValue(2.2, "two point two")
 					ctx.WithValue("action", "destroy")
 					ctx.Request().Next()
 				})
@@ -564,6 +588,9 @@ func abortMiddleware() contractshttp.Middleware {
 
 func contextMiddleware() contractshttp.Middleware {
 	return func(ctx contractshttp.Context) {
+		type customKey struct{}
+		var customKeyCtx customKey
+		ctx.WithValue(customKeyCtx, "context with custom key")
 		ctx.WithValue("ctx", "Goravel")
 
 		ctx.Request().Next()
@@ -572,6 +599,7 @@ func contextMiddleware() contractshttp.Middleware {
 
 func contextMiddleware1() contractshttp.Middleware {
 	return func(ctx contractshttp.Context) {
+		ctx.WithValue(2.2, "two point two")
 		ctx.WithValue("ctx1", "Hello")
 
 		ctx.Request().Next()


### PR DESCRIPTION
## 📑 Description

Implementation of [#630](https://github.com/goravel/framework/pull/630)

Since the underlying gin does not support `any` as the key type, we use `Ctx` which is `context.Context` as the bag instead and only used as a bag. Because the cancellation signal should only come from the underlying gin instead of the goravel itself.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new context management system for improved handling of key-value pairs.
	- Enhanced flexibility in storing and retrieving various data types within the context.

- **Bug Fixes**
	- Updated context retrieval methods to prevent runtime errors from type mismatches.

- **Tests**
	- Expanded test coverage to include new key-value pairs and custom types for context validation.

- **Chores**
	- Updated dependency version for improved performance and potential new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
