### PR TITLE
fix: Context method

### DIFF
--- a/context.go
+++ b/context.go
@@ -111,7 +111,11 @@ func (c *Context) Err() error {
 }
 
 func (c *Context) Value(key any) any {
-	return c.getGoravelContextValues()[key]
+	if value, exist := c.getGoravelContextValues()[key]; exist {
+		return value
+	}
+
+	return c.instance.Request.Context().Value(key)
 }
 
 func (c *Context) Instance() *gin.Context {

--- a/context.go
+++ b/context.go
@@ -10,7 +10,19 @@ import (
 	"github.com/goravel/framework/contracts/http"
 )
 
-const goravelContextKey = "goravel_contextKey"
+const (
+	contextKey        = "goravel_contextKey"
+	responseOriginKey = "goravel_responseOrigin"
+	sessionKey        = "goravel_session"
+)
+
+var (
+	internalContextKeys = []any{
+		contextKey,
+		responseOriginKey,
+		sessionKey,
+	}
+)
 
 func Background() http.Context {
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
@@ -48,7 +60,7 @@ func (c *Context) Response() http.ContextResponse {
 		c.response = response
 	}
 
-	responseOrigin := c.Value("responseOrigin")
+	responseOrigin := c.Value(responseOriginKey)
 	if responseOrigin != nil {
 		c.response.(*ContextResponse).origin = responseOrigin.(http.ResponseOrigin)
 	}
@@ -57,9 +69,9 @@ func (c *Context) Response() http.ContextResponse {
 }
 
 func (c *Context) WithValue(key any, value any) {
-	goravelCtx := c.getGoravelCtx()
-	goravelCtx[key] = value
-	c.instance.Set(goravelContextKey, goravelCtx)
+	values := c.getGoravelContextValues()
+	values[key] = value
+	c.instance.Set(contextKey, values)
 }
 
 func (c *Context) WithContext(ctx context.Context) {
@@ -67,7 +79,24 @@ func (c *Context) WithContext(ctx context.Context) {
 	c.instance.Request = c.instance.Request.WithContext(ctx)
 }
 
-func (c *Context) Context() context.Context { return c }
+func (c *Context) Context() context.Context {
+	ctx := c.instance.Request.Context()
+	values := c.getGoravelContextValues()
+	for key, value := range values {
+		skip := false
+		for _, internalContextKey := range internalContextKeys {
+			if key == internalContextKey {
+				skip = true
+			}
+		}
+
+		if !skip {
+			ctx = context.WithValue(ctx, key, value)
+		}
+	}
+
+	return ctx
+}
 
 func (c *Context) Deadline() (deadline time.Time, ok bool) {
 	return c.instance.Deadline()
@@ -82,15 +111,15 @@ func (c *Context) Err() error {
 }
 
 func (c *Context) Value(key any) any {
-	return c.getGoravelCtx()[key]
+	return c.getGoravelContextValues()[key]
 }
 
 func (c *Context) Instance() *gin.Context {
 	return c.instance
 }
 
-func (c *Context) getGoravelCtx() map[any]any {
-	if val, exist := c.instance.Get(goravelContextKey); exist {
+func (c *Context) getGoravelContextValues() map[any]any {
+	if val, exist := c.instance.Get(contextKey); exist {
 		if goravelCtxVal, ok := val.(map[any]any); ok {
 			return goravelCtxVal
 		}

--- a/context_request.go
+++ b/context_request.go
@@ -157,7 +157,7 @@ func (r *ContextRequest) Host() string {
 }
 
 func (r *ContextRequest) HasSession() bool {
-	_, ok := r.ctx.Value("session").(contractsession.Session)
+	_, ok := r.ctx.Value(sessionKey).(contractsession.Session)
 	return ok
 }
 
@@ -385,7 +385,7 @@ func (r *ContextRequest) RouteInt64(key string) int64 {
 }
 
 func (r *ContextRequest) Session() contractsession.Session {
-	s, ok := r.ctx.Value("session").(contractsession.Session)
+	s, ok := r.ctx.Value(sessionKey).(contractsession.Session)
 	if !ok {
 		return nil
 	}
@@ -393,7 +393,7 @@ func (r *ContextRequest) Session() contractsession.Session {
 }
 
 func (r *ContextRequest) SetSession(session contractsession.Session) contractshttp.ContextRequest {
-	r.ctx.WithValue("session", session)
+	r.ctx.WithValue(sessionKey, session)
 
 	return r
 }

--- a/context_response.go
+++ b/context_response.go
@@ -153,7 +153,7 @@ func ResponseMiddleware() contractshttp.Middleware {
 			ctx.Instance().Writer = blw
 		}
 
-		ctx.WithValue("responseOrigin", blw)
+		ctx.WithValue(responseOriginKey, blw)
 		ctx.Request().Next()
 	}
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"context"
 	"net/http/httptest"
 	"testing"
 
@@ -9,12 +10,8 @@ import (
 )
 
 func TestContext(t *testing.T) {
-	// even with the same underlying empty struct, Go will still distinguish between
-	//  each type declaration
 	type customType struct{}
-	type anotherCustomType struct{}
 	var customTypeKey customType
-	var anotherCustomTypeKey anotherCustomType
 
 	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
 	ginCtx.Request = httptest.NewRequest("GET", "/", nil)
@@ -22,15 +19,29 @@ func TestContext(t *testing.T) {
 	httpCtx.WithValue("Hello", "world")
 	httpCtx.WithValue("Hi", "Goravel")
 	httpCtx.WithValue(customTypeKey, "halo")
-	httpCtx.WithValue(anotherCustomTypeKey, "hola")
+
+	userContext := context.Background()
+	userContext = context.WithValue(userContext, "user_a", "b")
+	httpCtx.WithContext(userContext)
+
 	httpCtx.WithValue(1, "one")
 	httpCtx.WithValue(2.2, "two point two")
 
+	assert.Equal(t, "world", httpCtx.Value("Hello"))
+	assert.Equal(t, "Goravel", httpCtx.Value("Hi"))
+	assert.Equal(t, "halo", httpCtx.Value(customTypeKey))
+	assert.Equal(t, "one", httpCtx.Value(1))
+	assert.Equal(t, "two point two", httpCtx.Value(2.2))
+
+	// The value of UserContext can't be covered.
+	assert.Equal(t, "b", httpCtx.Value("user_a"))
+
 	ctx := httpCtx.Context()
+
 	assert.Equal(t, "world", ctx.Value("Hello"))
 	assert.Equal(t, "Goravel", ctx.Value("Hi"))
 	assert.Equal(t, "halo", ctx.Value(customTypeKey))
-	assert.Equal(t, "hola", ctx.Value(anotherCustomTypeKey))
+	assert.Equal(t, "b", ctx.Value("user_a"))
 	assert.Equal(t, "one", ctx.Value(1))
 	assert.Equal(t, "two point two", ctx.Value(2.2))
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,8 +1,10 @@
 package gin
 
 import (
+	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,7 +16,9 @@ func TestContext(t *testing.T) {
 	var customTypeKey customType
 	var anotherCustomTypeKey anotherCustomType
 
-	httpCtx := Background()
+	ginCtx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ginCtx.Request = httptest.NewRequest("GET", "/", nil)
+	httpCtx := NewContext(ginCtx)
 	httpCtx.WithValue("Hello", "world")
 	httpCtx.WithValue("Hi", "Goravel")
 	httpCtx.WithValue(customTypeKey, "halo")

--- a/context_test.go
+++ b/context_test.go
@@ -21,6 +21,7 @@ func TestContext(t *testing.T) {
 	httpCtx.WithValue(customTypeKey, "halo")
 
 	userContext := context.Background()
+	//nolint:all
 	userContext = context.WithValue(userContext, "user_a", "b")
 	httpCtx.WithContext(userContext)
 


### PR DESCRIPTION
## 📑 Description

Previously, the context returned by the `Context` method can't get value normally, because we maintain a customized value.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced context management with improved key handling for session and response origin.
  
- **Bug Fixes**
	- Standardized session management to reduce hard-coded string errors.

- **Tests**
	- Updated test initialization for context to improve reliability and added user-specific context handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
