### PR TITLE
fix: link

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/gookit/validate v1.5.4
 	github.com/goravel/framework v1.15.1
 	github.com/rs/cors v1.11.1
-	github.com/savioxavier/termlink v1.4.1
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0
 	github.com/unrolled/secure v1.17.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.23.4
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/gookit/validate v1.5.4
-	github.com/goravel/framework v1.15.1
+	github.com/goravel/framework v1.15.2
 	github.com/rs/cors v1.11.1
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -551,8 +551,6 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
 github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
-github.com/savioxavier/termlink v1.4.1 h1:pFcd+XH8iQjL+2mB4buCDUo+CMt5kKsr8jGG+VLfYAg=
-github.com/savioxavier/termlink v1.4.1/go.mod h1:5T5ePUlWbxCHIwyF8/Ez1qufOoGM89RCg9NvG+3G3gc=
 github.com/sergi/go-diff v1.2.0 h1:XU+rvMAioB0UC3q1MFrIQy4Vo5/4VsRDQQXHsEya6xQ=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.sum
+++ b/go.sum
@@ -370,8 +370,8 @@ github.com/gookit/validate v1.5.4 h1:nwBo6vULnVUeNFCOde6RKFRbOCKJXVMnWR0ghedacLg
 github.com/gookit/validate v1.5.4/go.mod h1:p9sRPfpvYB4vXICBpEPzv8FoAky+XhUOhWQghgmmat4=
 github.com/goravel/file-rotatelogs/v2 v2.4.2 h1:g68AzbePXcm0V2CpUMc9j4qVzcDn7+7aoWSjZ51C0m4=
 github.com/goravel/file-rotatelogs/v2 v2.4.2/go.mod h1:23VuSW8cBS4ax5cmbV+5AaiLpq25b8UJ96IhbAkdo8I=
-github.com/goravel/framework v1.15.1 h1:9K5Vf51+0YIQbLMd1+hk0L7LDBMaAmeLlQnoHJu6wow=
-github.com/goravel/framework v1.15.1/go.mod h1:Qo5Xlf+slrosyMxBKbNoxpEmzB6y2C5FI4BHNdVOSyI=
+github.com/goravel/framework v1.15.2 h1:wC76iwXWpYz3Oj+WQKw/kC4yGluDIeRdmPFKQW3t47M=
+github.com/goravel/framework v1.15.2/go.mod h1:Qo5Xlf+slrosyMxBKbNoxpEmzB6y2C5FI4BHNdVOSyI=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/route.go
+++ b/route.go
@@ -16,6 +16,7 @@ import (
 	"github.com/goravel/framework/contracts/route"
 	"github.com/goravel/framework/support"
 	"github.com/goravel/framework/support/color"
+	"github.com/goravel/framework/support/str"
 )
 
 var globalRecoverCallback func(ctx contractshttp.Context, err any) = func(ctx contractshttp.Context, err any) {
@@ -109,7 +110,7 @@ func (r *Route) Recover(callback func(ctx contractshttp.Context, err any)) {
 
 func (r *Route) Listen(l net.Listener) error {
 	r.outputRoutes()
-	color.Green().Println("[HTTP] Listening on: http://" + l.Addr().String())
+	color.Green().Println("[HTTP] Listening on: " + str.Of(l.Addr().String()).Start("http://").String())
 
 	r.server = &http.Server{
 		Addr:           l.Addr().String(),
@@ -130,7 +131,7 @@ func (r *Route) ListenTLS(l net.Listener) error {
 
 func (r *Route) ListenTLSWithCert(l net.Listener, certFile, keyFile string) error {
 	r.outputRoutes()
-	color.Green().Println("[HTTPS] Listening on: https://" + l.Addr().String())
+	color.Green().Println("[HTTPS] Listening on: " + str.Of(l.Addr().String()).Start("https://").String())
 
 	r.tlsServer = &http.Server{
 		Addr:           l.Addr().String(),
@@ -157,7 +158,7 @@ func (r *Route) Run(host ...string) error {
 	}
 
 	r.outputRoutes()
-	color.Green().Println("[HTTP] Listening on: http://" + host[0])
+	color.Green().Println("[HTTP] Listening on: " + str.Of(host[0]).Start("http://").String())
 
 	r.server = &http.Server{
 		Addr:           host[0],
@@ -198,7 +199,7 @@ func (r *Route) RunTLSWithCert(host, certFile, keyFile string) error {
 	}
 
 	r.outputRoutes()
-	color.Green().Println("[HTTPS] Listening on: https://" + host)
+	color.Green().Println("[HTTPS] Listening on: " + str.Of(host).Start("https://").String())
 
 	r.tlsServer = &http.Server{
 		Addr:           host,

--- a/route.go
+++ b/route.go
@@ -16,7 +16,6 @@ import (
 	"github.com/goravel/framework/contracts/route"
 	"github.com/goravel/framework/support"
 	"github.com/goravel/framework/support/color"
-	"github.com/savioxavier/termlink"
 )
 
 var globalRecoverCallback func(ctx contractshttp.Context, err any) = func(ctx contractshttp.Context, err any) {
@@ -110,7 +109,7 @@ func (r *Route) Recover(callback func(ctx contractshttp.Context, err any)) {
 
 func (r *Route) Listen(l net.Listener) error {
 	r.outputRoutes()
-	color.Green().Println(termlink.Link("[HTTP] Listening and serving HTTP on", "http://"+l.Addr().String()))
+	color.Green().Println("[HTTP] Listening on: http://" + l.Addr().String())
 
 	r.server = &http.Server{
 		Addr:           l.Addr().String(),
@@ -131,7 +130,7 @@ func (r *Route) ListenTLS(l net.Listener) error {
 
 func (r *Route) ListenTLSWithCert(l net.Listener, certFile, keyFile string) error {
 	r.outputRoutes()
-	color.Green().Println(termlink.Link("[HTTPS] Listening and serving HTTPS on", "https://"+l.Addr().String()))
+	color.Green().Println("[HTTPS] Listening on: https://" + l.Addr().String())
 
 	r.tlsServer = &http.Server{
 		Addr:           l.Addr().String(),
@@ -158,7 +157,7 @@ func (r *Route) Run(host ...string) error {
 	}
 
 	r.outputRoutes()
-	color.Green().Println(termlink.Link("[HTTP] Listening and serving HTTP on", "http://"+host[0]))
+	color.Green().Println("[HTTP] Listening on: http://" + host[0])
 
 	r.server = &http.Server{
 		Addr:           host[0],
@@ -199,7 +198,7 @@ func (r *Route) RunTLSWithCert(host, certFile, keyFile string) error {
 	}
 
 	r.outputRoutes()
-	color.Green().Println(termlink.Link("[HTTPS] Listening and serving HTTPS on", "https://"+host))
+	color.Green().Println("[HTTPS] Listening on: https://" + host)
 
 	r.tlsServer = &http.Server{
 		Addr:           host,


### PR DESCRIPTION
## 📑 Description

Some terminals can't print link correctly. We can print the link directly, all terminals enable clicking the link when pushing CTRL.

<img width="623" alt="image" src="https://github.com/user-attachments/assets/2f893b17-db76-4bad-bc37-b3883ac1bf69" />

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
@coderabbitai summary
<!-- Trigger AI description by commenting @coderabbitai summary -->
