### PR TITLE
feat: [#408] Optimize the backslash

### DIFF
--- a/group.go
+++ b/group.go
@@ -34,7 +34,11 @@ func (r *Group) Group(handler route.GroupFunc) {
 	middlewares = append(middlewares, r.originMiddlewares...)
 	middlewares = append(middlewares, r.middlewares...)
 	r.middlewares = []httpcontract.Middleware{}
-	prefix := pathToGinPath(r.originPrefix + "/" + r.prefix)
+
+	prefix := r.originPrefix
+	if r.prefix != "" {
+		prefix += "/" + r.prefix
+	}
 	r.prefix = ""
 
 	handler(NewGroup(r.config, r.instance, prefix, middlewares, r.lastMiddlewares))
@@ -113,7 +117,11 @@ func (r *Group) StaticFS(relativePath string, fs http.FileSystem) {
 }
 
 func (r *Group) getRoutesWithMiddlewares() gin.IRoutes {
-	prefix := pathToGinPath(r.originPrefix + "/" + r.prefix)
+	prefix := r.originPrefix
+	if r.prefix != "" {
+		prefix += "/" + r.prefix
+	}
+	prefix = pathToGinPath(prefix)
 
 	r.prefix = ""
 	ginGroup := r.instance.Group(prefix)


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/408

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request refactors the route prefix handling in the `Group` struct, updates related test cases, and adds a new test to address a specific issue. The most important changes include improving how prefixes are concatenated, updating imports and type references in tests, and introducing a new test case for issue #408.

### Refactoring of prefix handling:
* Updated the `Group` methods (`Group` and `StaticFS`) to handle route prefix concatenation more robustly by checking if `r.prefix` is empty before appending it. This ensures cleaner and more predictable prefix construction. (`group.go`, [[1]](diffhunk://#diff-996f64128c7fffe6cc8254ea4e1ac3c5693956f86ab5c8952e525083cf14ca27L37-R41) [[2]](diffhunk://#diff-996f64128c7fffe6cc8254ea4e1ac3c5693956f86ab5c8952e525083cf14ca27L116-R124)

### Updates to test cases:
* Changed imports in `group_test.go` to use an alias (`contractsroute`) for the `route` package, aligning with naming conventions.
* Updated test cases in `TestGroup` to reflect the new alias (`contractsroute.Router`) in place of `route.Router`. This ensures consistency with the updated import. [[1]](diffhunk://#diff-176c4119baca13b177944712c9a1f0813fe8a0d03e408d7b1725f38d1bcf5a6aL373-R374) [[2]](diffhunk://#diff-176c4119baca13b177944712c9a1f0813fe8a0d03e408d7b1725f38d1bcf5a6aL400-R401) [[3]](diffhunk://#diff-176c4119baca13b177944712c9a1f0813fe8a0d03e408d7b1725f38d1bcf5a6aL452-R452)

### Addition of a new test for issue #408:
* Added a new test case, `TestIssue408`, to verify that route prefixes with placeholders (e.g., `prefix/{id}`) are correctly handled, ensuring proper path construction for both `GET` and `POST` methods.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
