### PR TITLE
feat: [#647] ctx.Request().All() can be called multiple times

### DIFF
--- a/context_request_test.go
+++ b/context_request_test.go
@@ -213,6 +213,28 @@ func (s *ContextRequestSuite) TestAll_PostWithEmptyJson() {
 	s.Equal(http.StatusOK, code)
 }
 
+func (s *ContextRequestSuite) TestAll_PostWithMiddleware() {
+	s.route.Middleware(testAllMiddleware()).Post("/all-with-middleware", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"all":        ctx.Request().All(),
+			"middleware": ctx.Value("all"),
+		})
+	})
+
+	payload := strings.NewReader(`{
+		"Name": "goravel",
+		"Age": 1
+	}`)
+	req, err := http.NewRequest("POST", "/all-with-middleware?a=1&a=2&name=3", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/json")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"all\":{\"Age\":1,\"Name\":\"goravel\",\"a\":\"1,2\",\"name\":\"3\"},\"middleware\":{\"Age\":1,\"Name\":\"goravel\",\"a\":\"1,2\",\"name\":\"3\"}}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestAll_PutWithJson() {
 	s.route.Put("/all", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{
@@ -2027,5 +2049,15 @@ func TestGetValueFromHttpBody(t *testing.T) {
 			value := contextRequest.getValueFromHttpBody(test.key)
 			assert.Equal(t, test.expectValue, value)
 		})
+	}
+}
+
+// Timeout creates middleware to set a timeout for a request
+func testAllMiddleware() contractshttp.Middleware {
+	return func(ctx contractshttp.Context) {
+		all := ctx.Request().All()
+		ctx.WithValue("all", all)
+
+		ctx.Request().Next()
 	}
 }


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/647

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request adds functionality to test middleware behavior in the `ContextRequestSuite` and introduces a new middleware function for handling request data. The changes primarily focus on enhancing test coverage and middleware capabilities.

### Enhancements to test coverage:

* [`context_request_test.go`](diffhunk://#diff-44aea9709a440b6e3af7dfeccdfd7bd040b956e3c659af71e7f14c7fb207a476R216-R237): Added a new test case, `TestAll_PostWithMiddleware`, to verify the behavior of middleware when handling request data. This test ensures that middleware processes request data correctly and that the response includes both raw request data and middleware-modified data.

### Middleware functionality:

* [`context_request_test.go`](diffhunk://#diff-44aea9709a440b6e3af7dfeccdfd7bd040b956e3c659af71e7f14c7fb207a476R2054-R2063): Introduced a new middleware function, `testAllMiddleware`, which processes request data by storing it in the context for further use. This middleware demonstrates how to modify and pass data through the request lifecycle.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
