### PR TITLE
fix: preserve timeout without pooled context reuse

### DIFF
--- a/context.go
+++ b/context.go
@@ -2,12 +2,13 @@ package gin
 
 import (
 	"context"
+	nethttp "net/http"
 	"net/http/httptest"
 	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/goravel/framework/contracts/http"
+	contractshttp "github.com/goravel/framework/contracts/http"
 )
 
 const (
@@ -24,8 +25,9 @@ var (
 	}
 )
 
-func Background() http.Context {
+func Background() contractshttp.Context {
 	ctx, _ := gin.CreateTestContext(httptest.NewRecorder())
+	ctx.Request = httptest.NewRequest(nethttp.MethodGet, "/", nil)
 	return NewContext(ctx)
 }
 
@@ -35,8 +37,8 @@ var contextPool = sync.Pool{New: func() any {
 
 type Context struct {
 	instance *gin.Context
-	request  http.ContextRequest
-	response http.ContextResponse
+	request  contractshttp.ContextRequest
+	response contractshttp.ContextResponse
 }
 
 func NewContext(c *gin.Context) *Context {
@@ -45,7 +47,7 @@ func NewContext(c *gin.Context) *Context {
 	return ctx
 }
 
-func (c *Context) Request() http.ContextRequest {
+func (c *Context) Request() contractshttp.ContextRequest {
 	if c.request == nil {
 		request := NewContextRequest(c, LogFacade, ValidationFacade)
 		c.request = request
@@ -54,7 +56,7 @@ func (c *Context) Request() http.ContextRequest {
 	return c.request
 }
 
-func (c *Context) Response() http.ContextResponse {
+func (c *Context) Response() contractshttp.ContextResponse {
 	if c.response == nil {
 		response := NewContextResponse(c.instance, &BodyWriter{ResponseWriter: c.instance.Writer})
 		c.response = response
@@ -62,7 +64,7 @@ func (c *Context) Response() http.ContextResponse {
 
 	responseOrigin := c.Value(responseOriginKey)
 	if responseOrigin != nil {
-		c.response.(*ContextResponse).origin = responseOrigin.(http.ResponseOrigin)
+		c.response.(*ContextResponse).origin = responseOrigin.(contractshttp.ResponseOrigin)
 	}
 
 	return c.response
@@ -76,10 +78,12 @@ func (c *Context) WithValue(key any, value any) {
 
 func (c *Context) WithContext(ctx context.Context) {
 	// Changing the request context to a new context
+	c.ensureRequest()
 	c.instance.Request = c.instance.Request.WithContext(ctx)
 }
 
 func (c *Context) Context() context.Context {
+	c.ensureRequest()
 	ctx := c.instance.Request.Context()
 	values := c.getGoravelContextValues()
 	for key, value := range values {
@@ -99,14 +103,17 @@ func (c *Context) Context() context.Context {
 }
 
 func (c *Context) Deadline() (deadline time.Time, ok bool) {
+	c.ensureRequest()
 	return c.instance.Request.Context().Deadline()
 }
 
 func (c *Context) Done() <-chan struct{} {
+	c.ensureRequest()
 	return c.instance.Request.Context().Done()
 }
 
 func (c *Context) Err() error {
+	c.ensureRequest()
 	return c.instance.Request.Context().Err()
 }
 
@@ -115,6 +122,7 @@ func (c *Context) Value(key any) any {
 		return value
 	}
 
+	c.ensureRequest()
 	return c.instance.Request.Context().Value(key)
 }
 
@@ -129,4 +137,10 @@ func (c *Context) getGoravelContextValues() map[any]any {
 		}
 	}
 	return make(map[any]any)
+}
+
+func (c *Context) ensureRequest() {
+	if c.instance.Request == nil {
+		c.instance.Request = httptest.NewRequest(nethttp.MethodGet, "/", nil)
+	}
 }

--- a/context.go
+++ b/context.go
@@ -43,6 +43,9 @@ type Context struct {
 
 func NewContext(c *gin.Context) *Context {
 	ctx := contextPool.Get().(*Context)
+	if c.Request == nil {
+		c.Request = httptest.NewRequest(nethttp.MethodGet, "/", nil)
+	}
 	ctx.instance = c
 	return ctx
 }
@@ -78,12 +81,10 @@ func (c *Context) WithValue(key any, value any) {
 
 func (c *Context) WithContext(ctx context.Context) {
 	// Changing the request context to a new context
-	c.ensureRequest()
 	c.instance.Request = c.instance.Request.WithContext(ctx)
 }
 
 func (c *Context) Context() context.Context {
-	c.ensureRequest()
 	ctx := c.instance.Request.Context()
 	values := c.getGoravelContextValues()
 	for key, value := range values {
@@ -103,17 +104,14 @@ func (c *Context) Context() context.Context {
 }
 
 func (c *Context) Deadline() (deadline time.Time, ok bool) {
-	c.ensureRequest()
 	return c.instance.Request.Context().Deadline()
 }
 
 func (c *Context) Done() <-chan struct{} {
-	c.ensureRequest()
 	return c.instance.Request.Context().Done()
 }
 
 func (c *Context) Err() error {
-	c.ensureRequest()
 	return c.instance.Request.Context().Err()
 }
 
@@ -122,7 +120,6 @@ func (c *Context) Value(key any) any {
 		return value
 	}
 
-	c.ensureRequest()
 	return c.instance.Request.Context().Value(key)
 }
 
@@ -137,10 +134,4 @@ func (c *Context) getGoravelContextValues() map[any]any {
 		}
 	}
 	return make(map[any]any)
-}
-
-func (c *Context) ensureRequest() {
-	if c.instance.Request == nil {
-		c.instance.Request = httptest.NewRequest(nethttp.MethodGet, "/", nil)
-	}
 }

--- a/context.go
+++ b/context.go
@@ -43,6 +43,8 @@ type Context struct {
 
 func NewContext(c *gin.Context) *Context {
 	ctx := contextPool.Get().(*Context)
+	// Some test-created gin contexts do not carry a request, but Goravel's
+	// context accessors always read through Request.Context().
 	if c.Request == nil {
 		c.Request = httptest.NewRequest(nethttp.MethodGet, "/", nil)
 	}

--- a/context.go
+++ b/context.go
@@ -99,15 +99,15 @@ func (c *Context) Context() context.Context {
 }
 
 func (c *Context) Deadline() (deadline time.Time, ok bool) {
-	return c.instance.Deadline()
+	return c.instance.Request.Context().Deadline()
 }
 
 func (c *Context) Done() <-chan struct{} {
-	return c.instance.Done()
+	return c.instance.Request.Context().Done()
 }
 
 func (c *Context) Err() error {
-	return c.instance.Err()
+	return c.instance.Request.Context().Err()
 }
 
 func (c *Context) Value(key any) any {

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 toolchain go1.26.3
 
 require (
+	github.com/gin-contrib/timeout v1.2.1
 	github.com/gin-gonic/gin v1.12.0
 	github.com/goravel/framework v1.17.2-0.20260319074756-7cd523f5f1a5
 	github.com/rs/cors v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,8 @@ github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
 github.com/gin-contrib/sse v1.1.0/go.mod h1:hxRZ5gVpWMT7Z0B0gSNYqqsSCNIJMjzvm6fqCz9vjwM=
+github.com/gin-contrib/timeout v1.2.1 h1:vw+1K+rDo1M86G00A1RdQZDP9JJDcJjYj6+9ZVowjlk=
+github.com/gin-contrib/timeout v1.2.1/go.mod h1:sUImmGGy/39JoCfTRnouXWJRVuUvR0DGcdRorXn7VdE=
 github.com/gin-gonic/gin v1.12.0 h1:b3YAbrZtnf8N//yjKeU2+MQsh2mY5htkZidOM7O0wG8=
 github.com/gin-gonic/gin v1.12.0/go.mod h1:VxccKfsSllpKshkBWgVgRniFFAzFb9csfngsqANjnLc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -4,24 +4,38 @@ import (
 	"context"
 	"time"
 
+	gintimeout "github.com/gin-contrib/timeout"
+	"github.com/gin-gonic/gin"
 	contractshttp "github.com/goravel/framework/contracts/http"
 )
 
 // Timeout creates middleware to set a timeout for a request
 func Timeout(timeout time.Duration) contractshttp.Middleware {
+	timeoutResponse := func(c *gin.Context) {
+		c.Status(contractshttp.StatusRequestTimeout)
+	}
+
+	timeoutMiddleware := gintimeout.New(
+		gintimeout.WithTimeout(timeout),
+		gintimeout.WithResponse(timeoutResponse),
+	)
+
 	return func(ctx contractshttp.Context) {
 		if timeout <= 0 {
 			ctx.Request().Next()
 			return
 		}
 
-		timeoutCtx, cancel := context.WithTimeout(ctx.Context(), timeout)
-		defer cancel()
+		goravelCtx, ok := ctx.(*Context)
+		if !ok {
+			timeoutCtx, cancel := context.WithTimeout(ctx.Context(), timeout)
+			defer cancel()
 
-		ctx.WithContext(timeoutCtx)
+			ctx.WithContext(timeoutCtx)
+			ctx.Request().Next()
+			return
+		}
 
-		// Run the request chain synchronously so pooled request wrappers are not
-		// returned while downstream handlers are still using them.
-		ctx.Request().Next()
+		timeoutMiddleware(goravelCtx.Instance())
 	}
 }

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -5,20 +5,12 @@ import (
 	"time"
 
 	gintimeout "github.com/gin-contrib/timeout"
-	"github.com/gin-gonic/gin"
 	contractshttp "github.com/goravel/framework/contracts/http"
 )
 
 // Timeout creates middleware to set a timeout for a request
 func Timeout(timeout time.Duration) contractshttp.Middleware {
-	timeoutResponse := func(c *gin.Context) {
-		c.Status(contractshttp.StatusRequestTimeout)
-	}
-
-	timeoutMiddleware := gintimeout.New(
-		gintimeout.WithTimeout(timeout),
-		gintimeout.WithResponse(timeoutResponse),
-	)
+	timeoutMiddleware := gintimeout.New(gintimeout.WithTimeout(timeout))
 
 	return func(ctx contractshttp.Context) {
 		if timeout <= 0 {

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -1,7 +1,6 @@
 package gin
 
 import (
-	"context"
 	"time"
 
 	gintimeout "github.com/gin-contrib/timeout"
@@ -18,16 +17,6 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 			return
 		}
 
-		goravelCtx, ok := ctx.(*Context)
-		if !ok {
-			timeoutCtx, cancel := context.WithTimeout(ctx.Context(), timeout)
-			defer cancel()
-
-			ctx.WithContext(timeoutCtx)
-			ctx.Request().Next()
-			return
-		}
-
-		timeoutMiddleware(goravelCtx.Instance())
+		timeoutMiddleware(ctx.(*Context).Instance())
 	}
 }

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	contractshttp "github.com/goravel/framework/contracts/http"
-	"github.com/goravel/framework/errors"
 )
 
 // Timeout creates middleware to set a timeout for a request
@@ -21,25 +20,8 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 
 		ctx.WithContext(timeoutCtx)
 
-		done := make(chan struct{})
-
-		go func() {
-			defer func() {
-				if err := recover(); err != nil {
-					globalRecoverCallback(ctx, err)
-				}
-
-				close(done)
-			}()
-			ctx.Request().Next()
-		}()
-
-		select {
-		case <-done:
-		case <-timeoutCtx.Done():
-			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
-				ctx.Request().Abort(contractshttp.StatusRequestTimeout)
-			}
-		}
+		// Run the request chain synchronously so pooled request wrappers are not
+		// returned while downstream handlers are still using them.
+		ctx.Request().Next()
 	}
 }

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -1,6 +1,7 @@
 package gin
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -28,11 +29,18 @@ func TestTimeoutMiddleware(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("timeout waits for handler completion", func(t *testing.T) {
+		var (
+			err         error
+			deadline    time.Time
+			hasDeadline bool
+		)
 		timedOut := make(chan struct{})
 		allowReturn := make(chan struct{})
 
 		route.Middleware(Timeout(20*time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
 			<-ctx.Done()
+			err = ctx.Err()
+			deadline, hasDeadline = ctx.Deadline()
 			close(timedOut)
 			<-allowReturn
 
@@ -71,6 +79,9 @@ func TestTimeoutMiddleware(t *testing.T) {
 
 		assert.Equal(t, contractshttp.StatusRequestTimeout, w.Code)
 		assert.Equal(t, http.StatusText(contractshttp.StatusRequestTimeout), w.Body.String())
+		assert.ErrorIs(t, err, context.DeadlineExceeded)
+		assert.True(t, hasDeadline)
+		assert.False(t, deadline.IsZero())
 	})
 
 	t.Run("normal request", func(t *testing.T) {

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -27,18 +27,50 @@ func TestTimeoutMiddleware(t *testing.T) {
 	err := route.init(nil)
 	require.Nil(t, err)
 
-	t.Run("timeout request", func(t *testing.T) {
-		route.Middleware(Timeout(1*time.Second)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
-			time.Sleep(2 * time.Second)
-			return nil
+	t.Run("timeout waits for handler completion", func(t *testing.T) {
+		timedOut := make(chan struct{})
+		allowReturn := make(chan struct{})
+
+		route.Middleware(Timeout(20*time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
+			<-ctx.Done()
+			close(timedOut)
+			<-allowReturn
+
+			return ctx.Response().Status(contractshttp.StatusRequestTimeout).String("timeout")
 		})
 
 		w := httptest.NewRecorder()
 		req, err := http.NewRequest("GET", "/timeout", nil)
 		require.NoError(t, err)
+		done := make(chan struct{})
 
-		route.ServeHTTP(w, req)
+		go func() {
+			route.ServeHTTP(w, req)
+			close(done)
+		}()
+
+		select {
+		case <-timedOut:
+		case <-time.After(time.Second):
+			t.Fatal("request context deadline was not observed")
+		}
+
+		select {
+		case <-done:
+			t.Fatal("request returned before the handler completed")
+		default:
+		}
+
+		close(allowReturn)
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("request did not complete after the handler returned")
+		}
+
 		assert.Equal(t, contractshttp.StatusRequestTimeout, w.Code)
+		assert.Equal(t, "timeout", w.Body.String())
 	})
 
 	t.Run("normal request", func(t *testing.T) {
@@ -53,6 +85,62 @@ func TestTimeoutMiddleware(t *testing.T) {
 		route.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Equal(t, "normal", w.Body.String())
+	})
+
+	t.Run("timed out request does not affect later responses", func(t *testing.T) {
+		timedOut := make(chan struct{})
+		allowReturn := make(chan struct{})
+		firstDone := make(chan struct{})
+
+		route.Middleware(Timeout(20*time.Millisecond)).Get("/timeout-isolated", func(ctx contractshttp.Context) contractshttp.Response {
+			<-ctx.Done()
+			close(timedOut)
+			<-allowReturn
+
+			return ctx.Response().Success().String("stale")
+		})
+		route.Middleware(Timeout(time.Second)).Get("/after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
+			return ctx.Response().Success().String("fresh")
+		})
+
+		firstWriter := httptest.NewRecorder()
+		firstReq, err := http.NewRequest("GET", "/timeout-isolated", nil)
+		require.NoError(t, err)
+
+		go func() {
+			route.ServeHTTP(firstWriter, firstReq)
+			close(firstDone)
+		}()
+
+		select {
+		case <-timedOut:
+		case <-time.After(time.Second):
+			t.Fatal("request context deadline was not observed")
+		}
+
+		secondWriter := httptest.NewRecorder()
+		secondReq, err := http.NewRequest("GET", "/after-timeout", nil)
+		require.NoError(t, err)
+		route.ServeHTTP(secondWriter, secondReq)
+
+		select {
+		case <-firstDone:
+			t.Fatal("timed out request returned before its handler completed")
+		default:
+		}
+
+		close(allowReturn)
+
+		select {
+		case <-firstDone:
+		case <-time.After(time.Second):
+			t.Fatal("timed out request did not complete after the handler returned")
+		}
+
+		assert.Equal(t, http.StatusOK, firstWriter.Code)
+		assert.Equal(t, "stale", firstWriter.Body.String())
+		assert.Equal(t, http.StatusOK, secondWriter.Code)
+		assert.Equal(t, "fresh", secondWriter.Body.String())
 	})
 
 	t.Run("panic with default recover", func(t *testing.T) {

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -70,7 +70,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 		}
 
 		assert.Equal(t, contractshttp.StatusRequestTimeout, w.Code)
-		assert.Empty(t, w.Body.String())
+		assert.Equal(t, http.StatusText(contractshttp.StatusRequestTimeout), w.Body.String())
 	})
 
 	t.Run("normal request", func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 		}
 
 		assert.Equal(t, contractshttp.StatusRequestTimeout, firstWriter.Code)
-		assert.Empty(t, firstWriter.Body.String())
+		assert.Equal(t, http.StatusText(contractshttp.StatusRequestTimeout), firstWriter.Body.String())
 		assert.Equal(t, http.StatusOK, secondWriter.Code)
 		assert.Equal(t, "fresh", secondWriter.Body.String())
 	})

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -70,7 +70,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 		}
 
 		assert.Equal(t, contractshttp.StatusRequestTimeout, w.Code)
-		assert.Equal(t, "timeout", w.Body.String())
+		assert.Empty(t, w.Body.String())
 	})
 
 	t.Run("normal request", func(t *testing.T) {
@@ -137,8 +137,8 @@ func TestTimeoutMiddleware(t *testing.T) {
 			t.Fatal("timed out request did not complete after the handler returned")
 		}
 
-		assert.Equal(t, http.StatusOK, firstWriter.Code)
-		assert.Equal(t, "stale", firstWriter.Body.String())
+		assert.Equal(t, contractshttp.StatusRequestTimeout, firstWriter.Code)
+		assert.Empty(t, firstWriter.Body.String())
 		assert.Equal(t, http.StatusOK, secondWriter.Code)
 		assert.Equal(t, "fresh", secondWriter.Body.String())
 	})


### PR DESCRIPTION
## Summary
- Keep automatic request timeouts while replacing the unsafe custom timeout runner with `gin-contrib/timeout` internally.
- Preserve `408 Request Timeout` responses while preventing late writes from a timed-out request from leaking into the next request.
- Add regression coverage for timeout completion ordering and request isolation after a timeout.

Closes https://github.com/goravel/goravel/issues/966

## Why
The previous timeout middleware enforced timeouts by running the Gin chain in a background goroutine and returning as soon as the deadline fired. That made Goravel return pooled request and response wrappers before the timed-out handler had actually stopped, which could let late writes bleed into a later request.

This change keeps the timeout feature instead of removing it. Goravel still exposes the same `Timeout(...)` middleware and still returns HTTP 408 on timeout, but the implementation now delegates to `gin-contrib/timeout`, which buffers the response, suppresses late writes after timeout, and waits for the worker goroutine to finish before control returns to Gin's pooled context lifecycle.

```go
facades.Route().Get("/ping", func(ctx http.Context) http.Response {
	select {
	case <-time.After(5 * time.Second):
		return ctx.Response().Success().Json(http.Json{
			"code":    0,
			"message": "OK",
			"data":    []any{},
			"errors":  []any{},
		})
	case <-ctx.Done():
		return nil
	}
})
```