### PR TITLE
fix: replace same name cookie instead of appending a duplicate Set-Cookie

### DIFF
--- a/context_response.go
+++ b/context_response.go
@@ -3,6 +3,7 @@ package gin
 import (
 	"bytes"
 	"net/http"
+	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
@@ -42,6 +43,7 @@ func (r *ContextResponse) Cookie(cookie contractshttp.Cookie) contractshttp.Cont
 		r.instance.SetSameSite(sameSite)
 	}
 
+	removeSetCookie(r.instance.Writer.Header(), cookie.Name)
 	r.instance.SetCookie(cookie.Name, cookie.Value, cookie.MaxAge, cookie.Path, cookie.Domain, cookie.Secure, cookie.HttpOnly)
 
 	return r
@@ -106,9 +108,35 @@ func (r *ContextResponse) View() contractshttp.ResponseView {
 }
 
 func (r *ContextResponse) WithoutCookie(name string) contractshttp.ContextResponse {
+	removeSetCookie(r.instance.Writer.Header(), name)
 	r.instance.SetCookie(name, "", -1, "", "", false, false)
 
 	return r
+}
+
+// removeSetCookie drops Set-Cookie headers already written for name, so the
+// response carries a single value per cookie (RFC 6265 section 4.1.1).
+func removeSetCookie(header http.Header, name string) {
+	values := header.Values("Set-Cookie")
+	if len(values) == 0 {
+		return
+	}
+
+	prefix := name + "="
+	kept := make([]string, 0, len(values))
+	for _, value := range values {
+		if !strings.HasPrefix(value, prefix) {
+			kept = append(kept, value)
+		}
+	}
+	if len(kept) == len(values) {
+		return
+	}
+
+	header.Del("Set-Cookie")
+	for _, value := range kept {
+		header.Add("Set-Cookie", value)
+	}
 }
 
 func (r *ContextResponse) Writer() http.ResponseWriter {

--- a/context_response.go
+++ b/context_response.go
@@ -3,7 +3,6 @@ package gin
 import (
 	"bytes"
 	"net/http"
-	"strings"
 	"sync"
 
 	"github.com/gin-gonic/gin"
@@ -115,28 +114,30 @@ func (r *ContextResponse) WithoutCookie(name string) contractshttp.ContextRespon
 }
 
 // removeSetCookie drops Set-Cookie headers already written for name, so the
-// response carries a single value per cookie (RFC 6265 section 4.1.1).
+// response carries a single value per cookie (RFC 6265 section 4.1.1), the
+// same replace semantics fasthttp applies in ResponseHeader.SetCookie.
 func removeSetCookie(header http.Header, name string) {
 	values := header.Values("Set-Cookie")
 	if len(values) == 0 {
 		return
 	}
 
-	prefix := name + "="
 	kept := make([]string, 0, len(values))
 	for _, value := range values {
-		if !strings.HasPrefix(value, prefix) {
-			kept = append(kept, value)
+		if cookie, err := http.ParseSetCookie(value); err == nil && cookie.Name == name {
+			continue
 		}
+		kept = append(kept, value)
 	}
 	if len(kept) == len(values) {
 		return
 	}
 
-	header.Del("Set-Cookie")
-	for _, value := range kept {
-		header.Add("Set-Cookie", value)
+	if len(kept) == 0 {
+		header.Del("Set-Cookie")
+		return
 	}
+	header["Set-Cookie"] = kept
 }
 
 func (r *ContextResponse) Writer() http.ResponseWriter {

--- a/context_response.go
+++ b/context_response.go
@@ -133,11 +133,10 @@ func removeSetCookie(header http.Header, name string) {
 		return
 	}
 
-	if len(kept) == 0 {
-		header.Del("Set-Cookie")
-		return
+	header.Del("Set-Cookie")
+	for _, value := range kept {
+		header.Add("Set-Cookie", value)
 	}
-	header["Set-Cookie"] = kept
 }
 
 func (r *ContextResponse) Writer() http.ResponseWriter {

--- a/context_response.go
+++ b/context_response.go
@@ -113,32 +113,6 @@ func (r *ContextResponse) WithoutCookie(name string) contractshttp.ContextRespon
 	return r
 }
 
-// removeSetCookie drops Set-Cookie headers already written for name, so the
-// response carries a single value per cookie (RFC 6265 section 4.1.1), the
-// same replace semantics fasthttp applies in ResponseHeader.SetCookie.
-func removeSetCookie(header http.Header, name string) {
-	values := header.Values("Set-Cookie")
-	if len(values) == 0 {
-		return
-	}
-
-	kept := make([]string, 0, len(values))
-	for _, value := range values {
-		if cookie, err := http.ParseSetCookie(value); err == nil && cookie.Name == name {
-			continue
-		}
-		kept = append(kept, value)
-	}
-	if len(kept) == len(values) {
-		return
-	}
-
-	header.Del("Set-Cookie")
-	for _, value := range kept {
-		header.Add("Set-Cookie", value)
-	}
-}
-
 func (r *ContextResponse) Writer() http.ResponseWriter {
 	return r.instance.Writer
 }
@@ -209,4 +183,30 @@ func (w *BodyWriter) Body() *bytes.Buffer {
 
 func (w *BodyWriter) Header() http.Header {
 	return w.ResponseWriter.Header()
+}
+
+// removeSetCookie drops Set-Cookie headers already written for name, so the
+// response carries a single value per cookie (RFC 6265 section 4.1.1), the
+// same replace semantics fasthttp applies in ResponseHeader.SetCookie.
+func removeSetCookie(header http.Header, name string) {
+	values := header.Values("Set-Cookie")
+	if len(values) == 0 {
+		return
+	}
+
+	kept := make([]string, 0, len(values))
+	for _, value := range values {
+		if cookie, err := http.ParseSetCookie(value); err == nil && cookie.Name == name {
+			continue
+		}
+		kept = append(kept, value)
+	}
+	if len(kept) == len(values) {
+		return
+	}
+
+	header.Del("Set-Cookie")
+	for _, value := range kept {
+		header.Add("Set-Cookie", value)
+	}
 }

--- a/context_response_test.go
+++ b/context_response_test.go
@@ -60,6 +60,39 @@ func (s *ContextResponseSuite) TestCookie() {
 	s.True(exist)
 }
 
+func (s *ContextResponseSuite) TestCookie_SameNameReplaced() {
+	cookieName := "goravel"
+	s.route.Get("/cookie-replace", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Cookie(contractshttp.Cookie{
+			Name:  cookieName,
+			Value: "stale",
+		}).Cookie(contractshttp.Cookie{
+			Name:  "other",
+			Value: "kept",
+		}).Cookie(contractshttp.Cookie{
+			Name:  cookieName,
+			Value: "rotated",
+		}).String(http.StatusOK, "Goravel")
+	})
+
+	code, _, _, cookies := s.request("GET", "/cookie-replace", nil)
+
+	s.Equal(http.StatusOK, code)
+
+	var values []string
+	otherKept := false
+	for _, cookie := range cookies {
+		if cookie.Name == cookieName {
+			values = append(values, cookie.Value)
+		}
+		if cookie.Name == "other" {
+			otherKept = true
+		}
+	}
+	s.Equal([]string{"rotated"}, values)
+	s.True(otherKept)
+}
+
 func (s *ContextResponseSuite) TestData() {
 	s.route.Get("/data", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Data(http.StatusOK, "text/html; charset=utf-8", []byte("<b>Goravel</b>"))

--- a/context_response_test.go
+++ b/context_response_test.go
@@ -10,6 +10,7 @@ import (
 
 	contractshttp "github.com/goravel/framework/contracts/http"
 	mocksconfig "github.com/goravel/framework/mocks/config"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -91,6 +92,30 @@ func (s *ContextResponseSuite) TestCookie_SameNameReplaced() {
 	}
 	s.Equal([]string{"rotated"}, values)
 	s.True(otherKept)
+}
+
+func (s *ContextResponseSuite) TestWithoutCookie_AfterCookie() {
+	cookieName := "goravel"
+	s.route.Get("/cookie-clear", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Cookie(contractshttp.Cookie{
+			Name:  cookieName,
+			Value: "Goravel",
+		}).WithoutCookie(cookieName).String(http.StatusOK, "Goravel")
+	})
+
+	code, _, _, cookies := s.request("GET", "/cookie-clear", nil)
+
+	s.Equal(http.StatusOK, code)
+
+	var matched []*http.Cookie
+	for _, cookie := range cookies {
+		if cookie.Name == cookieName {
+			matched = append(matched, cookie)
+		}
+	}
+	s.Require().Len(matched, 1)
+	s.Empty(matched[0].Value)
+	s.Equal(-1, matched[0].MaxAge)
 }
 
 func (s *ContextResponseSuite) TestData() {
@@ -390,5 +415,61 @@ func testRedirect() contractshttp.Middleware {
 			panic(err)
 		}
 		ctx.Request().Next()
+	}
+}
+
+func TestRemoveSetCookie(t *testing.T) {
+	tests := []struct {
+		name       string
+		existing   []string
+		cookieName string
+		expect     []string
+	}{
+		{
+			name:       "no headers",
+			cookieName: "session",
+		},
+		{
+			name:       "removes only the matching name",
+			existing:   []string{"session=old; Path=/", "other=kept; Path=/"},
+			cookieName: "session",
+			expect:     []string{"other=kept; Path=/"},
+		},
+		{
+			name:       "keeps names sharing a prefix",
+			existing:   []string{"session=old", "session2=kept", "xsession=kept"},
+			cookieName: "session",
+			expect:     []string{"session2=kept", "xsession=kept"},
+		},
+		{
+			name:       "removes every occurrence",
+			existing:   []string{"session=a", "session=b"},
+			cookieName: "session",
+		},
+		{
+			name:       "keeps values that fail to parse",
+			existing:   []string{"not a set-cookie", "session=old"},
+			cookieName: "session",
+			expect:     []string{"not a set-cookie"},
+		},
+		{
+			name:       "no match leaves headers untouched",
+			existing:   []string{"other=kept"},
+			cookieName: "session",
+			expect:     []string{"other=kept"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := http.Header{}
+			for _, value := range tt.existing {
+				header.Add("Set-Cookie", value)
+			}
+
+			removeSetCookie(header, tt.cookieName)
+
+			assert.Equal(t, tt.expect, header.Values("Set-Cookie"))
+		})
 	}
 }


### PR DESCRIPTION
## 📑 Description

RelatedTo goravel/goravel#925

`Response().Cookie()` appends a new `Set-Cookie` header every call, so setting the same cookie twice in one request (the session guard re-issues the session cookie after rotating the ID on login/logout) sends two headers for the same name. RFC 6265 section 4.1.1 recommends against this, browsers keep the last one, but clients that read the first match (including Go's `Request.Cookie`) get the stale value. fiber already replaces by name via fasthttp.

Drop any `Set-Cookie` already written for the name before setting it, in both `Cookie` and `WithoutCookie`.

## ✅ Checks

- [x] Added test cases for my code
