### PR TITLE
fix: preserve single-element InputArray values

### DIFF
--- a/context_request.go
+++ b/context_request.go
@@ -373,6 +373,14 @@ func (r *ContextRequest) Input(key string, defaultValue ...string) string {
 
 func (r *ContextRequest) InputArray(key string, defaultValue ...[]string) []string {
 	if valueFromHttpBody := r.getValueFromHttpBody(key); valueFromHttpBody != nil {
+		if value, ok := valueFromHttpBody.(string); ok {
+			if value == "" {
+				return []string{}
+			}
+
+			return []string{value}
+		}
+
 		if value := cast.ToStringSlice(valueFromHttpBody); value == nil {
 			return []string{}
 		} else {

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -1086,6 +1086,32 @@ func (s *ContextRequestSuite) TestInputArray_Form() {
 	s.Equal(http.StatusOK, code)
 }
 
+func (s *ContextRequestSuite) TestInputArray_FormWithSingleValue() {
+	s.route.Post("/input-array/form-single/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"InputArray":  ctx.Request().InputArray("arr[]"),
+			"InputArray1": ctx.Request().InputArray("arr"),
+		})
+	})
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	err := writer.WriteField("arr[]", "123 456 789")
+	s.Require().Nil(err)
+
+	err = writer.Close()
+	s.Require().Nil(err)
+
+	req, err := http.NewRequest("POST", "/input-array/form-single/1?id=2", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"InputArray\":[\"123 456 789\"],\"InputArray1\":[\"123 456 789\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestInputArray_Url() {
 	s.route.Post("/input-array/url/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{
@@ -1104,6 +1130,27 @@ func (s *ContextRequestSuite) TestInputArray_Url() {
 	code, body, _, _ := s.request(req)
 
 	s.Equal("{\"string\":[\"string 0\",\"string 1\"],\"string1\":[\"string 0\",\"string 1\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
+func (s *ContextRequestSuite) TestInputArray_UrlWithSingleValue() {
+	s.route.Post("/input-array/url-single/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"string":  ctx.Request().InputArray("string[]"),
+			"string1": ctx.Request().InputArray("string"),
+		})
+	})
+
+	form := neturl.Values{
+		"string[]": {"123 456 789"},
+	}
+	req, err := http.NewRequest("POST", "/input-array/url-single/1?id=2", strings.NewReader(form.Encode()))
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"string\":[\"123 456 789\"],\"string1\":[\"123 456 789\"]}", body)
 	s.Equal(http.StatusOK, code)
 }
 

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -1112,6 +1112,35 @@ func (s *ContextRequestSuite) TestInputArray_FormWithSingleValue() {
 	s.Equal(http.StatusOK, code)
 }
 
+func (s *ContextRequestSuite) TestInputArray_FormWithMultipleValuesContainingSpaces() {
+	s.route.Post("/input-array/form-multiple/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"InputArray":  ctx.Request().InputArray("arr[]"),
+			"InputArray1": ctx.Request().InputArray("arr"),
+		})
+	})
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	err := writer.WriteField("arr[]", "123 456")
+	s.Require().Nil(err)
+
+	err = writer.WriteField("arr[]", "789 012")
+	s.Require().Nil(err)
+
+	err = writer.Close()
+	s.Require().Nil(err)
+
+	req, err := http.NewRequest("POST", "/input-array/form-multiple/1?id=2", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"InputArray\":[\"123 456\",\"789 012\"],\"InputArray1\":[\"123 456\",\"789 012\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestInputArray_Url() {
 	s.route.Post("/input-array/url/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{


### PR DESCRIPTION
## Summary
- Preserve single form values with spaces as one `InputArray` entry.
- Keep empty body values returning an empty string slice.
- Cover multipart and URL-encoded single-value array inputs.

Closes https://github.com/goravel/goravel/issues/961

## Why
`ctx.Request().InputArray` should reflect submitted array entries without splitting an individual value on whitespace. Before this fix, the same controller code returned `[]string{"123", "456", "789"}` when `prompt_content_text[]` contained one form value of `123 456 789`; after this fix, it returns `[]string{"123 456 789"}`.

```go
func (r *PromptController) Store(ctx http.Context) http.Response {
	contentText := ctx.Request().InputArray("prompt_content_text[]")

	return ctx.Response().Success().Json(http.Json{
		"content_text": contentText,
	})
}
```

The fix keeps multi-value form arrays unchanged and adds coverage for both multipart and URL-encoded form submissions so single submitted values stay intact.
