### PR TITLE
fix: preserve single-element InputArray values

### DIFF
--- a/context_request.go
+++ b/context_request.go
@@ -370,6 +370,14 @@ func (r *ContextRequest) Input(key string, defaultValue ...string) string {
 
 func (r *ContextRequest) InputArray(key string, defaultValue ...[]string) []string {
 	if valueFromHttpBody := r.getValueFromHttpBody(key); valueFromHttpBody != nil {
+		if value, ok := valueFromHttpBody.(string); ok {
+			if value == "" {
+				return []string{}
+			}
+
+			return []string{value}
+		}
+
 		if value := cast.ToStringSlice(valueFromHttpBody); value == nil {
 			return []string{}
 		} else {

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -1086,6 +1086,61 @@ func (s *ContextRequestSuite) TestInputArray_Form() {
 	s.Equal(http.StatusOK, code)
 }
 
+func (s *ContextRequestSuite) TestInputArray_FormWithSingleValue() {
+	s.route.Post("/input-array/form-single/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"InputArray":  ctx.Request().InputArray("arr[]"),
+			"InputArray1": ctx.Request().InputArray("arr"),
+		})
+	})
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	err := writer.WriteField("arr[]", "123 456 789")
+	s.Require().Nil(err)
+
+	err = writer.Close()
+	s.Require().Nil(err)
+
+	req, err := http.NewRequest("POST", "/input-array/form-single/1?id=2", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"InputArray\":[\"123 456 789\"],\"InputArray1\":[\"123 456 789\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
+func (s *ContextRequestSuite) TestInputArray_FormWithMultipleValuesContainingSpaces() {
+	s.route.Post("/input-array/form-multiple/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"InputArray":  ctx.Request().InputArray("arr[]"),
+			"InputArray1": ctx.Request().InputArray("arr"),
+		})
+	})
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	err := writer.WriteField("arr[]", "123 456")
+	s.Require().Nil(err)
+
+	err = writer.WriteField("arr[]", "789 012")
+	s.Require().Nil(err)
+
+	err = writer.Close()
+	s.Require().Nil(err)
+
+	req, err := http.NewRequest("POST", "/input-array/form-multiple/1?id=2", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"InputArray\":[\"123 456\",\"789 012\"],\"InputArray1\":[\"123 456\",\"789 012\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestInputArray_Url() {
 	s.route.Post("/input-array/url/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{
@@ -1104,6 +1159,27 @@ func (s *ContextRequestSuite) TestInputArray_Url() {
 	code, body, _, _ := s.request(req)
 
 	s.Equal("{\"string\":[\"string 0\",\"string 1\"],\"string1\":[\"string 0\",\"string 1\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
+func (s *ContextRequestSuite) TestInputArray_UrlWithSingleValue() {
+	s.route.Post("/input-array/url-single/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"string":  ctx.Request().InputArray("string[]"),
+			"string1": ctx.Request().InputArray("string"),
+		})
+	})
+
+	form := neturl.Values{
+		"string[]": {"123 456 789"},
+	}
+	req, err := http.NewRequest("POST", "/input-array/url-single/1?id=2", strings.NewReader(form.Encode()))
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"string\":[\"123 456 789\"],\"string1\":[\"123 456 789\"]}", body)
 	s.Equal(http.StatusOK, code)
 }
 

--- a/group.go
+++ b/group.go
@@ -153,7 +153,7 @@ func (r *Group) getHandlerName(handler any) string {
 			prefix string
 			t      = reflect.TypeOf(res)
 		)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			prefix = "*"
 			t = t.Elem()
 		}


### PR DESCRIPTION
## Summary
- Preserve single form body values with spaces as one `InputArray` entry.
- Keep empty body values returning an empty string slice.
- Cover multipart and URL-encoded single-value array inputs.

Closes https://github.com/goravel/goravel/issues/961

## Why
`InputArray` should treat a single submitted array field the same way developers see it in the request payload. Before this change, a multipart or URL-encoded value such as `123 456 789` could be split into multiple entries instead of staying as one value.

```go
func (r *UserController) Store(ctx http.Context) http.Response {
	return ctx.Response().Success().Json(http.Json{
		"tags": ctx.Request().InputArray("tags"),
	})
}
```

After this fix, form submissions like `tags[]=goravel framework` return `[]string{"goravel framework"}` while empty body values still return an empty slice.
