### PR TITLE
fix: [#989] defer view template compilation to first serve call

### DIFF
--- a/route.go
+++ b/route.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -50,6 +51,8 @@ type Route struct {
 	instance         *gin.Engine
 	server           *http.Server
 	tlsServer        *http.Server
+	templateOnce     sync.Once
+	templateErr      error
 }
 
 func NewRoute(config config.Config, parameters map[string]any) (*Route, error) {
@@ -110,6 +113,10 @@ func (r *Route) GlobalMiddleware(middleware ...contractshttp.Middleware) {
 }
 
 func (r *Route) Listen(l net.Listener) error {
+	if err := r.ensureTemplate(); err != nil {
+		return err
+	}
+
 	r.outputRoutes()
 	color.Green().Println("[HTTP] Listening on: " + str.Of(l.Addr().String()).Start("http://").String())
 
@@ -131,6 +138,10 @@ func (r *Route) ListenTLS(l net.Listener) error {
 }
 
 func (r *Route) ListenTLSWithCert(l net.Listener, certFile, keyFile string) error {
+	if err := r.ensureTemplate(); err != nil {
+		return err
+	}
+
 	r.outputRoutes()
 	color.Green().Println("[HTTPS] Listening on: " + str.Of(l.Addr().String()).Start("https://").String())
 
@@ -167,6 +178,10 @@ func (r *Route) Recover(callback func(ctx contractshttp.Context, err any)) {
 }
 
 func (r *Route) Run(host ...string) error {
+	if err := r.ensureTemplate(); err != nil {
+		return err
+	}
+
 	if len(host) == 0 {
 		defaultHost := r.config.GetString("http.host")
 		defaultPort := r.config.GetString("http.port")
@@ -211,6 +226,10 @@ func (r *Route) RunTLS(host ...string) error {
 }
 
 func (r *Route) RunTLSWithCert(host, certFile, keyFile string) error {
+	if err := r.ensureTemplate(); err != nil {
+		return err
+	}
+
 	if host == "" {
 		return errors.New("host can't be empty")
 	}
@@ -235,6 +254,20 @@ func (r *Route) RunTLSWithCert(host, certFile, keyFile string) error {
 }
 
 func (r *Route) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	if err := r.ensureTemplate(); err != nil {
+		// ensureTemplate() runs before the recover middleware, so a template compile
+		// error surfaces at request time. Log it and return a 500 instead of
+		// panicking: when embedded as an http.Handler, a panic here would be
+		// recovered by net/http without any HTTP response reaching the client.
+		// The response body carries the specific compile error, so the failure stays
+		// visible to the caller even when the log is not reachable.
+		if LogFacade != nil {
+			LogFacade.WithContext(request.Context()).Error(err)
+		}
+		http.Error(writer, err.Error(), http.StatusInternalServerError)
+
+		return
+	}
 	r.instance.ServeHTTP(writer, request)
 }
 
@@ -294,14 +327,10 @@ func (r *Route) init(globalMiddleware []contractshttp.Middleware) error {
 
 		engine.HTMLRender = htmlRender
 	}
-
-	if engine.HTMLRender == nil {
-		var err error
-		engine.HTMLRender, err = DefaultTemplate()
-		if err != nil {
-			return err
-		}
-	}
+	// NOTE: DefaultTemplate() is intentionally NOT called here. It is deferred to
+	// ensureTemplate(), invoked on the first Listen/Run/ServeHTTP call, so that views
+	// registered via View.LoadViewsFrom() in a provider's Boot() are picked up.
+	// See goravel/goravel#989.
 
 	r.Router = NewGroup(
 		r.config,
@@ -313,6 +342,37 @@ func (r *Route) init(globalMiddleware []contractshttp.Middleware) error {
 	r.instance = engine
 
 	return nil
+}
+
+// ensureTemplate lazily compiles the default template set on first use. It must
+// run after all service providers have booted so that ViewFacade is set and any
+// LoadViewsFrom()-registered directories are included.
+//
+// Compilation happens exactly once, at the first serve call. If no template
+// files exist, DefaultTemplate() returns (nil, nil) and HTMLRender stays nil
+// (gin's default), so views registered after that point are intentionally not
+// compiled. A compile failure is stored in templateErr and returned on every
+// call, so later requests keep failing with the real error instead of serving
+// with no renderer.
+//
+// The once/error state is Route-scoped while the compiled renderer lives on the
+// current engine (r.instance.HTMLRender), so a re-init() after first serve (via
+// GlobalMiddleware/SetGlobalMiddleware/Recover) would build a fresh engine that
+// the already-fired once will not recompile. This mirrors the bootstrap-only
+// design of re-init(), which already discards every registered route.
+func (r *Route) ensureTemplate() error {
+	r.templateOnce.Do(func() {
+		if r.instance.HTMLRender != nil {
+			return
+		}
+		var htmlRender render.HTMLRender
+		htmlRender, r.templateErr = DefaultTemplate()
+		if r.templateErr != nil {
+			return
+		}
+		r.instance.HTMLRender = htmlRender
+	})
+	return r.templateErr
 }
 
 func (r *Route) outputRoutes() {

--- a/route_test.go
+++ b/route_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -18,6 +19,9 @@ import (
 	"github.com/goravel/framework/contracts/validation"
 	configmocks "github.com/goravel/framework/mocks/config"
 	mockslog "github.com/goravel/framework/mocks/log"
+	mocksview "github.com/goravel/framework/mocks/view"
+	"github.com/goravel/framework/support/file"
+	"github.com/goravel/framework/support/path"
 	"github.com/spf13/cast"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -704,6 +708,154 @@ func (s *RouteTestSuite) TestTest() {
 	s.Equal("Hello, Goravel!", string(body))
 }
 
+// TestRoute_ServeHTTP_DeferredTemplatePackageViews reproduces goravel/goravel#989:
+// route.init() runs before service providers boot (ViewFacade is nil), then a
+// provider registers package views via View.LoadViewsFrom() during Boot(). The
+// default template set must be compiled lazily on the first serve call so those
+// views are included.
+func TestRoute_ServeHTTP_DeferredTemplatePackageViews(t *testing.T) {
+	// Note: path.Resource() (repo-relative resources/) is test-only scratch space;
+	// the gin repo has no resources/ directory and the defer below removes it.
+	pkgDir := path.Resource("pkg_view")
+	assert.Nil(t, os.MkdirAll(pkgDir, os.ModePerm))
+	assert.Nil(t, file.PutContent(path.Resource("pkg_view", "test.tmpl"), `{{ define "test.tmpl" }}Package View Rendered{{ end }}`))
+	defer func() {
+		ConfigFacade = nil
+		ViewFacade = nil
+		assert.Nil(t, file.Remove(path.Resource()))
+	}()
+
+	mockConfig := configmocks.NewConfig(t)
+	mockConfig.EXPECT().GetBool("app.debug").Return(false).Once()
+	mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
+	mockConfig.EXPECT().Get("http.drivers.gin.template").Return(nil).Once()
+	ConfigFacade = mockConfig
+
+	// init() runs before Boot(): ViewFacade is still nil at this point.
+	route := &Route{
+		config: mockConfig,
+		driver: "gin",
+	}
+	assert.Nil(t, route.init(nil))
+
+	// Boot() assigns ViewFacade and registers the package view directory.
+	mockView := mocksview.NewView(t)
+	mockView.EXPECT().RegisteredViews().Return([]string{pkgDir}).Once()
+	mockView.EXPECT().GetShared().Return(nil).Once()
+	ViewFacade = mockView
+
+	route.Get("/view", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().View().Make("test.tmpl")
+	})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/view", nil)
+	assert.Nil(t, err)
+	route.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "Package View Rendered", w.Body.String())
+}
+
+// TestRoute_ServeHTTP_DeferredTemplateDefaultAppViews is a regression test for
+// the default case: templates from the app's resources/views directory still
+// render through the serve path when no package views are registered.
+func TestRoute_ServeHTTP_DeferredTemplateDefaultAppViews(t *testing.T) {
+	// Note: path.Resource() (repo-relative resources/) is test-only scratch space;
+	// the gin repo has no resources/ directory and the defer below removes it.
+	assert.Nil(t, os.MkdirAll(path.Resource("views"), os.ModePerm))
+	assert.Nil(t, file.PutContent(path.Resource("views", "home.tmpl"), `{{ define "home.tmpl" }}Home Rendered{{ end }}`))
+	defer func() {
+		ConfigFacade = nil
+		ViewFacade = nil
+		assert.Nil(t, file.Remove(path.Resource()))
+	}()
+
+	mockConfig := configmocks.NewConfig(t)
+	mockConfig.EXPECT().GetBool("app.debug").Return(false).Once()
+	mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
+	mockConfig.EXPECT().Get("http.drivers.gin.template").Return(nil).Once()
+	ConfigFacade = mockConfig
+
+	route := &Route{
+		config: mockConfig,
+		driver: "gin",
+	}
+	assert.Nil(t, route.init(nil))
+
+	mockView := mocksview.NewView(t)
+	mockView.EXPECT().RegisteredViews().Return(nil).Once()
+	mockView.EXPECT().GetShared().Return(nil).Once()
+	ViewFacade = mockView
+
+	route.Get("/home", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().View().Make("home.tmpl")
+	})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/home", nil)
+	assert.Nil(t, err)
+	route.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "Home Rendered", w.Body.String())
+}
+
+// TestRoute_ServeHTTP_StickyTemplateError guards the ensureTemplate() contract that a
+// template compile failure is sticky: after the first request fails, later requests must
+// keep failing with a 500 through the ensureTemplate() error path instead of proceeding
+// to serve with no renderer (which would lose the real error).
+func TestRoute_ServeHTTP_StickyTemplateError(t *testing.T) {
+	// Note: path.Resource() (repo-relative resources/) is test-only scratch space;
+	// the gin repo has no resources/ directory and the defer below removes it.
+	// A malformed template makes DefaultTemplate() fail at compile time.
+	assert.Nil(t, os.MkdirAll(path.Resource("views"), os.ModePerm))
+	assert.Nil(t, file.PutContent(path.Resource("views", "bad.tmpl"), `{{ define "bad.tmpl" }}{{`))
+	defer func() {
+		ConfigFacade = nil
+		LogFacade = nil
+		ViewFacade = nil
+		assert.Nil(t, file.Remove(path.Resource()))
+	}()
+
+	mockConfig := configmocks.NewConfig(t)
+	mockConfig.EXPECT().GetBool("app.debug").Return(false).Once()
+	mockConfig.EXPECT().GetInt("http.drivers.gin.body_limit", 4096).Return(4096).Once()
+	mockConfig.EXPECT().Get("http.drivers.gin.template").Return(nil).Once()
+	ConfigFacade = mockConfig
+	// Neutralize any LogFacade left over from other tests: the ServeHTTP error path
+	// logs via LogFacade, and a stale mock would fail on the unexpected call.
+	LogFacade = nil
+
+	route := &Route{
+		config: mockConfig,
+		driver: "gin",
+	}
+	assert.Nil(t, route.init(nil))
+
+	route.Get("/", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().String("ok")
+	})
+
+	var body string
+	for i := 0; i < 2; i++ {
+		w := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "/", nil)
+		assert.Nil(t, err)
+		route.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusInternalServerError, w.Code)
+		body = w.Body.String()
+	}
+
+	// The compile error stays sticky for later serving entry points (Run/Listen) too.
+	err := route.ensureTemplate()
+	assert.NotNil(t, err)
+	// The response body carries the specific compile error so the failure is
+	// visible to the caller even when the log is not reachable.
+	assert.Equal(t, err.Error()+"\n", body)
+}
+
 func assertHttpNormal(t *testing.T, addr string, expectNormal bool) {
 	resp, err := http.DefaultClient.Get(addr)
 	if !expectNormal {
@@ -831,5 +983,5 @@ func (r *FileImageJson) PrepareForValidation(ctx contractshttp.Context, data val
 
 type routeTestMiddleware struct{}
 
-func (m *routeTestMiddleware) Signature() string       { return "routeTest" }
+func (m *routeTestMiddleware) Signature() string                { return "routeTest" }
 func (m *routeTestMiddleware) Handle(ctx contractshttp.Context) {}

--- a/template.go
+++ b/template.go
@@ -81,8 +81,12 @@ func NewTemplate(options RenderOptions) (*render.HTMLProduction, error) {
 	}
 
 	var extraViews []string
-	if ViewFacade != nil {
-		extraViews = ViewFacade.RegisteredViews()
+	viewFacade := ViewFacade
+	if viewFacade == nil && App != nil {
+		viewFacade = App.MakeView()
+	}
+	if viewFacade != nil {
+		extraViews = viewFacade.RegisteredViews()
 	}
 	for _, dir := range extraViews {
 		if !file.Exists(dir) {
@@ -120,6 +124,10 @@ func NewTemplate(options RenderOptions) (*render.HTMLProduction, error) {
 		}
 	}
 
+	// No views found (neither app resources/views nor registered package views):
+	// return (nil, nil) so callers keep their current renderer. For the deferred
+	// default-template path this means the template set is compiled exactly once
+	// at first serve — views registered later are not picked up.
 	if len(files) == 0 {
 		return nil, nil
 	}


### PR DESCRIPTION
## Summary
- Defer the default template-set compilation from route `init()` to the first serve call (`Run`/`Listen`/`ServeHTTP`) on the v1.18.x branch, so all service providers have booted before the default template renderer is compiled.
- Package views registered via `facades.View().LoadViewsFrom()` in a service provider's `Boot()` are now included in the compiled set; previously they were silently missing and rendering those views at request time failed.
- A template compilation failure is now sticky and visible: it is logged and returned as an HTTP `500` from `ServeHTTP`, and returned as an error from `Run`/`Listen`, instead of silently serving with no renderer.

Closes https://github.com/goravel/goravel/issues/989

## Why
This is a backport of goravel/gin#241 ("fix: [#989] defer view template compilation to first serve call") from `master` onto the `v1.18.x` release branch. The gin driver compiled its default template set eagerly inside `route.init()`, which runs before service providers have booted. At that point `ViewFacade` is still nil, so package views registered via `facades.View().LoadViewsFrom()` in a provider's `Boot()` were silently missing from the compiled set — rendering those views at request time failed. Default template compilation is now deferred to the first `Run`/`Listen`/`ServeHTTP` call, after all providers have booted, so `LoadViewsFrom()`-registered views are picked up.

A compile failure is stored on the route and re-returned on every call, so after a failed compile each request keeps failing with the real error (logged, then a `500`) rather than serving with no renderer and losing the error in a panic.

```go
// Before: the template set was compiled before providers booted, so views
// registered in Boot() were missing and rendering them failed at request time.
func (p *ServiceProvider) Boot(app foundation.Application) {
	facades.View().LoadViewsFrom("packages/blog/views")
}

facades.Route().Get("/post", func(ctx contractshttp.Context) contractshttp.Response {
	return ctx.Response().View().Make("post.tmpl")
})

// After: compilation is deferred to the first serve call, so the Boot()-registered
// views are included and the view renders successfully.
func (p *ServiceProvider) Boot(app foundation.Application) {
	facades.View().LoadViewsFrom("packages/blog/views")
}

facades.Route().Get("/post", func(ctx contractshttp.Context) contractshttp.Response {
	return ctx.Response().View().Make("post.tmpl")
})
```
